### PR TITLE
#53 Move FoundationDB impl source files to "foundationdb package

### DIFF
--- a/factstore-avro/src/test/kotlin/org/factstore/avro/AvroFactStoreTest.kt
+++ b/factstore-avro/src/test/kotlin/org/factstore/avro/AvroFactStoreTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.factstore.core.*
+import org.factstore.foundationdb.buildFdbFactStore
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance

--- a/factstore-fmodel/src/test/kotlin/org/factstore/fmodel/DcbTest.kt
+++ b/factstore-fmodel/src/test/kotlin/org/factstore/fmodel/DcbTest.kt
@@ -13,7 +13,7 @@ import org.factstore.core.FactId
 import org.factstore.core.FactStore
 import org.factstore.core.TagQuery
 import org.factstore.core.TagTypeItem
-import org.factstore.core.buildFdbFactStore
+import org.factstore.foundationdb.buildFdbFactStore
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FactStoreBuilder.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FactStoreBuilder.kt
@@ -1,6 +1,7 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import com.apple.foundationdb.FDB
+import org.factstore.core.FactStore
 
 fun buildFdbFactStore(
     clusterFilePath: String = "/etc/foundationdb/fdb.cluster",

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFact.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFact.kt
@@ -1,6 +1,7 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import com.apple.foundationdb.tuple.Tuple
+import org.factstore.core.Fact
 
 data class FdbFact(
     val fact: Fact,

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactAppender.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactAppender.kt
@@ -1,4 +1,4 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import com.apple.foundationdb.KeySelector
 import com.apple.foundationdb.ReadTransaction
@@ -6,6 +6,7 @@ import com.apple.foundationdb.Transaction
 import com.apple.foundationdb.tuple.Tuple
 import com.apple.foundationdb.tuple.Versionstamp
 import kotlinx.coroutines.future.await
+import org.factstore.core.*
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import kotlin.collections.orEmpty

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactFinder.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactFinder.kt
@@ -1,8 +1,9 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import com.apple.foundationdb.ReadTransaction
 import com.apple.foundationdb.tuple.Tuple
 import kotlinx.coroutines.future.await
+import org.factstore.core.*
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.CompletableFuture

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactStore.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactStore.kt
@@ -1,4 +1,4 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import com.apple.foundationdb.Database
 import com.apple.foundationdb.MutationType.SET_VERSIONSTAMPED_KEY
@@ -11,6 +11,7 @@ import com.apple.foundationdb.tuple.Versionstamp
 import com.github.avrokotlin.avro4k.Avro
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
+import org.factstore.core.*
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.CompletableFuture

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactStreamer.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactStreamer.kt
@@ -1,4 +1,4 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import com.apple.foundationdb.KeySelector
 import com.apple.foundationdb.Range
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.isActive
+import org.factstore.core.*
 import java.util.concurrent.CompletableFuture
 
 class FdbFactStreamer(private val store: FdbFactStore) : FactStreamer {

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/SerializableFdbFact.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/SerializableFdbFact.kt
@@ -1,4 +1,4 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable

--- a/factstore-foundationdb/src/test/kotlin/org/factstore/foundationdb/FactStoreTest.kt
+++ b/factstore-foundationdb/src/test/kotlin/org/factstore/foundationdb/FactStoreTest.kt
@@ -1,4 +1,4 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import com.apple.foundationdb.FDB
 import earth.adi.testcontainers.containers.FoundationDBContainer
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.factstore.core.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -875,7 +875,6 @@ class FactStoreTest {
     @Test
     fun testLargeDatasetQueryByTags(): Unit = runBlocking {
         // Step 1: Append 10,000 events with varying tags
-        val random = Random()
         val events = (1..10_000).map { index ->
             val tag = if (index % 2 == 0) "user" else "admin" // Use alternating tags
             val region = if (index % 2 == 0) "us" else "eu" // Use alternating regions

--- a/factstore-foundationdb/src/test/kotlin/org/factstore/foundationdb/FdbFactStoreResetHelper.kt
+++ b/factstore-foundationdb/src/test/kotlin/org/factstore/foundationdb/FdbFactStoreResetHelper.kt
@@ -1,4 +1,4 @@
-package org.factstore.core
+package org.factstore.foundationdb
 
 import com.apple.foundationdb.Database
 


### PR DESCRIPTION
This dev moves the FoundationDB-backed implementation from `org.factstore.core` (where also the main spec is contained) to its dedicated implementation package `org.factstore.foundationdb`.

We chose `foundationdb` over alternatives like `fdb` as it is more expressive, avoid ambuigity, and looks more coherent  with potential future implementations, like `memory`, `postgresql`.

As the FoundationDB depends on the core specification, new imports from `org.factstore.core` are needed.  