### PR TITLE
#57 Enforce uniqueness of FactIds

### DIFF
--- a/factstore-specification/src/main/kotlin/org/factstore/core/AppendRequest.kt
+++ b/factstore-specification/src/main/kotlin/org/factstore/core/AppendRequest.kt
@@ -9,7 +9,13 @@ data class AppendRequest(
     val facts: List<Fact>,
     val idempotencyKey: IdempotencyKey,
     val condition: AppendCondition = AppendCondition.None
-)
+) {
+
+    init {
+        require(facts.map { it.id }.distinct().size == facts.size) { "Duplicated FactId detected!" }
+    }
+
+}
 
 sealed interface AppendCondition {
 

--- a/factstore-specification/src/main/kotlin/org/factstore/core/FactStoreException.kt
+++ b/factstore-specification/src/main/kotlin/org/factstore/core/FactStoreException.kt
@@ -1,0 +1,27 @@
+package org.factstore.core
+
+/**
+ * Base exception type for all FactStore-related errors.
+ *
+ * This exception represents failures that indicate incorrect usage,
+ * violated invariants, or unrecoverable errors within the FactStore.
+ */
+sealed class FactStoreException(message: String) : RuntimeException(message)
+
+/**
+ * Base type for exceptions caused by invalid client requests.
+ *
+ * These exceptions indicate that the provided input violates fundamental
+ * constraints or invariants of the FactStore and cannot be processed
+ * successfully without modifying the request.
+ */
+sealed class InvalidAppendRequestException(message: String) : FactStoreException(message)
+
+/**
+ * Thrown when one or more facts with the same [FactId] already exist in the store.
+ *
+ * Fact identifiers are required to be globally unique. Attempting to append
+ * facts with identifiers that have already been used violates this invariant
+ * and results in a permanent failure.
+ */
+class DuplicateFactIdException(val factIds: List<FactId>) : InvalidAppendRequestException("FactId(s) $factIds already exists")

--- a/factstore-specification/src/test/kotlin/org/factstore/core/AppendRequestTest.kt
+++ b/factstore-specification/src/test/kotlin/org/factstore/core/AppendRequestTest.kt
@@ -1,0 +1,41 @@
+package org.factstore.core
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AppendRequestTest {
+
+    @Test
+    fun testUniqueFactId() {
+
+        val fact1 = Fact(
+            id = FactId.generate(),
+            subjectRef = SubjectRef(
+                type = "TEST_TYPE",
+                id = "TEST_ID",
+            ),
+            type = "TEST_FACT_TYPE",
+            payload = """DATA""".toByteArray(),
+            createdAt = Instant.now(),
+            tags = emptyMap()
+        )
+
+        val fact2 = fact1.copy() // fact2 shares the same factId
+
+        assertThatThrownBy {
+            AppendRequest(
+                facts = listOf(fact1, fact2),
+                idempotencyKey = IdempotencyKey(),
+                condition = AppendCondition.None
+            )
+        }
+
+        val fact3 = fact1.copy(id = FactId.generate())
+        AppendRequest(
+            facts = listOf(fact1, fact3), // no duplicated fact id
+            idempotencyKey = IdempotencyKey(),
+            condition = AppendCondition.None
+        )
+    }
+}


### PR DESCRIPTION
A FactId should be unique within a fact store. It is the responsibility of a FactStore to enforce global uniqueness of FactIds.