### PR TITLE
Raise proper exception for invalid fact streaming request

### DIFF
--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactStreamer.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactStreamer.kt
@@ -74,7 +74,7 @@ class FdbFactStreamer(private val store: FdbFactStore) : FactStreamer {
         return store.db.readAsync { tr ->
             tr.loadFact(factId).thenApply { internalFact ->
                 if (internalFact == null) {
-                    error("Fact with ID $factId not found!")
+                    throw FactIdNotFoundException(factId)
                 }
                 val positionTuple = internalFact.positionTuple
                 val byteArray = store.globalFactPositionSubspace.pack(positionTuple.add(factId.uuid))

--- a/factstore-specification/src/main/kotlin/org/factstore/core/FactStoreException.kt
+++ b/factstore-specification/src/main/kotlin/org/factstore/core/FactStoreException.kt
@@ -27,3 +27,27 @@ sealed class InvalidAppendRequestException(message: String) :
  */
 class DuplicateFactIdException(val factIds: List<FactId>) :
     InvalidAppendRequestException("FactId(s) $factIds already exists")
+
+/**
+ * Base type for exceptions caused by invalid streaming requests.
+ *
+ * These exceptions indicate that the provided streaming parameters
+ * cannot be satisfied by the current state of the FactStore.
+ */
+sealed class InvalidStreamingRequestException(message: String) :
+        FactStoreException(message)
+
+/**
+ * Thrown when a streaming request references a [FactId] that does not exist.
+ *
+ * This exception is typically raised when [StreamingOptionSet.lastSeenId]
+ * is set to a fact identifier that is unknown to the store.
+ *
+ * Streaming requires the last-seen fact to exist in order to resume
+ * deterministically from a known position.
+ *
+ * @property factId the fact identifier that could not be found
+ */
+class FactIdNotFoundException(val factId: FactId) :
+        InvalidStreamingRequestException("FactId $factId not found")
+

--- a/factstore-specification/src/main/kotlin/org/factstore/core/FactStreamer.kt
+++ b/factstore-specification/src/main/kotlin/org/factstore/core/FactStreamer.kt
@@ -22,9 +22,15 @@ interface FactStreamer {
      * The returned [Flow] emits facts incrementally and may continue emitting
      * new facts as they are appended to the store.
      *
+     * If [StreamingOptionSet.lastSeenId] is set and does not reference an
+     * existing fact, an [InvalidStreamingRequestException] is thrown.
+     *
      * @param streamingOptionSet configuration options controlling how facts
      * are streamed
      * @return a cold [Flow] emitting facts that match the streaming criteria
+     *
+     * @throws InvalidStreamingRequestException if the streaming request
+     * cannot be satisfied
      */
     fun streamAll(streamingOptionSet: StreamingOptionSet): Flow<Fact>
 
@@ -48,16 +54,23 @@ interface FactStreamer {
  * are available.
  *
  * @property lastSeenId the identifier of the last processed fact; streaming
- * will resume with the next fact after this identifier, or from the beginning
- * if `null`
+ * will resume with the next fact after this identifier.
+ * If the identifier does not exist, the streaming request is considered invalid.
  * @property batchSize the maximum number of facts fetched per polling cycle
  * @property pollDelayMs the delay in milliseconds between polling attempts
  * when no new facts are available
  *
- * @author Your Name
+ * @author Domenic Cassisi
  */
 data class StreamingOptionSet(
     val lastSeenId: FactId? = null,
     val batchSize: Int = 128,
     val pollDelayMs: Long = 250L
-)
+) {
+
+    init {
+        require(batchSize > 0) { "Batch size must be greater than zero, but was $batchSize" }
+        require(pollDelayMs > 0) { "Poll delay must be greater than zero, but was $pollDelayMs" }
+    }
+
+}

--- a/factstore-specification/src/test/kotlin/org/factstore/core/StreamingOptionSetTest.kt
+++ b/factstore-specification/src/test/kotlin/org/factstore/core/StreamingOptionSetTest.kt
@@ -1,0 +1,69 @@
+package org.factstore.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class StreamingOptionSetTest {
+
+    @Test
+    fun `should create StreamingOptionSet with default values`() {
+        val options = StreamingOptionSet()
+
+        assertThat(options.lastSeenId).isNull()
+        assertThat(options.batchSize).isEqualTo(128)
+        assertThat(options.pollDelayMs).isEqualTo(250L)
+    }
+
+    @Test
+    fun `should create StreamingOptionSet with custom values`() {
+        val lastSeenId = FactId(UUID.randomUUID())
+
+        val options = StreamingOptionSet(
+            lastSeenId = lastSeenId,
+            batchSize = 50,
+            pollDelayMs = 500L
+        )
+
+        assertThat(options.lastSeenId).isEqualTo(lastSeenId)
+        assertThat(options.batchSize).isEqualTo(50)
+        assertThat(options.pollDelayMs).isEqualTo(500L)
+    }
+
+    @Test
+    fun `should reject batchSize equal to zero`() {
+        assertThatThrownBy {
+            StreamingOptionSet(batchSize = 0)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Batch size must be greater than zero, but was 0")
+    }
+
+    @Test
+    fun `should reject batchSize less than zero`() {
+        assertThatThrownBy {
+            StreamingOptionSet(batchSize = -1)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Batch size must be greater than zero, but was -1")
+    }
+
+    @Test
+    fun `should reject pollDelayMs equal to zero`() {
+        assertThatThrownBy {
+            StreamingOptionSet(pollDelayMs = 0L)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Poll delay must be greater than zero, but was 0")
+    }
+
+    @Test
+    fun `should reject pollDelayMs less than zero`() {
+        assertThatThrownBy {
+            StreamingOptionSet(pollDelayMs = -10L)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("Poll delay must be greater than zero, but was -10")
+    }
+}


### PR DESCRIPTION
This development improves error handling for fact streaming by throwing a properly typed exception `FactIdNotFoundException` rather than `IllegalStateException`.