### PR TITLE
#67 Introduce proper types for tag keys, tag values, and fact types.

### DIFF
--- a/factstore-avro/src/main/kotlin/org/factstore/avro/AvroFdbStore.kt
+++ b/factstore-avro/src/main/kotlin/org/factstore/avro/AvroFdbStore.kt
@@ -86,7 +86,7 @@ object FactRegistry {
     }
 
     fun fromEnvelope(fact: Fact): Any {
-        val descriptor = byType[fact.type] ?: error("Unknown fact type ${fact.type}")
+        val descriptor = byType[fact.type.value] ?: error("Unknown fact type ${fact.type}")
         val serde = (descriptor as FactDescriptor<Any>).serializer
         return serde.deserialize(fact.payload)
     }
@@ -126,7 +126,7 @@ object FactRegistry {
 
         val fact = Fact(
             id = FactId.generate(),
-            type = factType,
+            type = org.factstore.core.FactType(factType),
             payload = factSerde.serialize(fact),
             subjectRef = SubjectRef(
                 type = subjectType,
@@ -134,7 +134,7 @@ object FactRegistry {
             ),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = tags
+            tags = tags.entries.associate { it.key.toTagKey() to it.value.toTagValue() }
         )
         return fact
     }

--- a/factstore-fmodel/src/test/kotlin/org/factstore/fmodel/DcbTest.kt
+++ b/factstore-fmodel/src/test/kotlin/org/factstore/fmodel/DcbTest.kt
@@ -11,8 +11,11 @@ import org.factstore.avro.createAvroFactDescriptor
 import org.factstore.core.AppendCondition
 import org.factstore.core.FactId
 import org.factstore.core.FactStore
+import org.factstore.core.FactType
+import org.factstore.core.TagKey
 import org.factstore.core.TagQuery
 import org.factstore.core.TagTypeItem
+import org.factstore.core.TagValue
 import org.factstore.foundationdb.buildFdbFactStore
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -64,8 +67,8 @@ class DcbTest {
             TagQuery(
                 queryItems = listOf(
                     TagTypeItem(
-                        listOf("PROJECT_ADDED"),
-                        tags = listOf("projectId" to projectId.toString())
+                        listOf(FactType("PROJECT_ADDED")),
+                        tags = listOf(TagKey("projectId") to TagValue(projectId.toString()))
                     )
                 )
             )

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactAppender.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactAppender.kt
@@ -172,15 +172,15 @@ class FdbFactAppender(
 
         // Helper function to create begin and end selectors for the range query
         fun createSelectors(
-            tag: Pair<String, String>,
+            tag: Pair<TagKey, TagValue>,
             afterPosition: Pair<Versionstamp, Long>?
         ): Pair<KeySelector, KeySelector> {
             val tuple = if (afterPosition != null) {
                 // If there's a afterPosition, include it in the tuple
-                Tuple.from(tag.first, tag.second, afterPosition.first, afterPosition.second)
+                Tuple.from(tag.first.value, tag.second.value, afterPosition.first, afterPosition.second)
             } else {
                 // If there's no afterPosition, just use the tag
-                Tuple.from(tag.first, tag.second)
+                Tuple.from(tag.first.value, tag.second.value)
             }
 
             // Create the beginSelector (first greater than if afterPosition is provided)
@@ -191,7 +191,7 @@ class FdbFactAppender(
             }
 
             // Create the end selector based on the tag range
-            val range = tagsIndexSubspace.range(Tuple.from(tag.first, tag.second))
+            val range = tagsIndexSubspace.range(Tuple.from(tag.first.value, tag.second.value))
             val endSelector = KeySelector.lastLessOrEqual(range.end)
 
             return Pair(beginSelector, endSelector)
@@ -225,14 +225,14 @@ class FdbFactAppender(
     ): CompletableFuture<Set<UUID>> {
         // Helper function to create start and end selectors
         fun createSelectors(
-            type: String,
-            tag: Pair<String, String>,
+            type: FactType,
+            tag: Pair<TagKey, TagValue>,
             afterPosition: Pair<Versionstamp, Long>?
         ): Pair<KeySelector, KeySelector> {
             val tuple = if (afterPosition != null) {
-                Tuple.from(type, tag.first, tag.second, afterPosition.first, afterPosition.second)
+                Tuple.from(type.value, tag.first.value, tag.second.value, afterPosition.first, afterPosition.second)
             } else {
-                Tuple.from(type, tag.first, tag.second)
+                Tuple.from(type.value, tag.first.value, tag.second.value)
             }
 
             val startKeySelector = if (afterPosition != null) {
@@ -241,7 +241,7 @@ class FdbFactAppender(
                 KeySelector(tagsTypeIndexSubspace.pack(tuple), OR_EQUAL, ZERO_OFFSET)
             }
 
-            val range = tagsTypeIndexSubspace.subspace(Tuple.from(type, tag.first, tag.second)).range()
+            val range = tagsTypeIndexSubspace.subspace(Tuple.from(type.value, tag.first.value, tag.second.value)).range()
             val endSelector = KeySelector.lastLessOrEqual(range.end)
 
             return Pair(startKeySelector, endSelector)

--- a/factstore-foundationdb/src/test/kotlin/org/factstore/foundationdb/FactStoreTest.kt
+++ b/factstore-foundationdb/src/test/kotlin/org/factstore/foundationdb/FactStoreTest.kt
@@ -75,7 +75,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_ONBOARDED",
+            type = "USER_ONBOARDED".toFactType(),
             payload = payload,
             createdAt = createdAt
         )
@@ -106,7 +106,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = now.minusSeconds(60) // 1 minute ago
         )
@@ -117,7 +117,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_UPDATED",
+            type = "USER_UPDATED".toFactType(),
             payload = """{ "username": "Alice", "status": "active" }""".toByteArray(),
             createdAt = now
         )
@@ -128,7 +128,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_DELETED",
+            type = "USER_DELETED".toFactType(),
             payload = """{ "username": "Bob" }""".toByteArray(),
             createdAt = now.plusSeconds(60) // 1 minute in the future
         )
@@ -156,7 +156,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -187,7 +187,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_LOCKED",
+            type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -241,7 +241,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -252,7 +252,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "BOB" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -263,7 +263,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_LOCKED",
+            type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -298,7 +298,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -309,7 +309,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "BOB" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -320,7 +320,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_LOCKED",
+            type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -351,7 +351,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = mapOf("test" to "123", "loc" to "world")
@@ -363,7 +363,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "BOB" }""".toByteArray(),
             createdAt = Instant.now()
         )
@@ -384,11 +384,11 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("role" to "admin", "region" to "eu")
+            tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("eu"))
         )
 
         val fact2 = Fact(
@@ -397,11 +397,11 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Bob" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("role" to "user", "region" to "us")
+            tags = mapOf(TagKey("role") to TagValue("user"), TagKey("region") to TagValue("us"))
         )
 
         val fact3 = Fact(
@@ -410,29 +410,29 @@ class FactStoreTest {
                 type = "USER",
                 id = "CHARLIE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Charlie" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("role" to "admin", "region" to "us")
+            tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("us"))
         )
 
         store.append(listOf(fact1, fact2, fact3))
 
         // --- Query 1: Find all role=admin (OR semantics → fact1 + fact3)
-        val adminFacts = store.findByTags(listOf("role" to "admin"))
+        val adminFacts = store.findByTags(listOf(TagKey("role") to TagValue("admin")))
         assertThat(adminFacts).containsExactly(fact1, fact3)
 
         // --- Query 2: Find all region=us (OR semantics → fact2 + fact3)
-        val usFacts = store.findByTags(listOf("region" to "us"))
+        val usFacts = store.findByTags(listOf(TagKey("region") to TagValue("us")))
         assertThat(usFacts).containsExactly(fact2, fact3)
 
         // --- Query 3: Find all role=admin OR region=eu (OR semantics → fact1 + fact3)
-        val adminOrEuFacts = store.findByTags(listOf("role" to "admin", "region" to "eu"))
+        val adminOrEuFacts = store.findByTags(listOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("eu")))
         assertThat(adminOrEuFacts).containsExactly(fact1, fact3)
 
         // --- Query 4: Non-existent tag → empty
-        val noFacts = store.findByTags(listOf("region" to "asia"))
+        val noFacts = store.findByTags(listOf(TagKey("region") to TagValue("asia")))
         assertThat(noFacts).isEmpty()
 
         // --- Query 5: Union of all queries (just to validate coverage)
@@ -440,7 +440,14 @@ class FactStoreTest {
         val fact1Loaded = store.findById(fact1.id)
         println(fact1Loaded)
 
-        val allFacts = store.findByTags(listOf("role" to "admin", "role" to "user", "region" to "eu", "region" to "us"))
+        val allFacts = store.findByTags(
+            listOf(
+                TagKey("role") to TagValue("admin"),
+                TagKey("role") to TagValue("user"),
+                TagKey("region") to TagValue("eu"),
+                TagKey("region") to TagValue("us")
+            )
+        )
         assertThat(allFacts).containsExactly(fact1, fact2, fact3)
     }
 
@@ -465,11 +472,11 @@ class FactStoreTest {
                     type = "USER",
                     id = "ALICE",
                 ),
-                type = "USER_CREATED",
+                type = "USER_CREATED".toFactType(),
                 payload = """{ "username": "Alice" }""".toByteArray(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
-                tags = mapOf("role" to "admin", "region" to "eu")
+                tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("eu"))
             )
 
             val fact2 = Fact(
@@ -478,11 +485,11 @@ class FactStoreTest {
                     type = "USER",
                     id = "BOB",
                 ),
-                type = "USER_CREATED",
+                type = "USER_CREATED".toFactType(),
                 payload = """{ "username": "Bob" }""".toByteArray(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
-                tags = mapOf("role" to "user", "region" to "us")
+                tags = mapOf(TagKey("role") to TagValue("user"), TagKey("region") to TagValue("us"))
             )
 
             val fact3 = Fact(
@@ -491,11 +498,11 @@ class FactStoreTest {
                     type = "USER",
                     id = "CHARLIE",
                 ),
-                type = "USER_CREATED",
+                type = "USER_CREATED".toFactType(),
                 payload = """{ "username": "Charlie" }""".toByteArray(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
-                tags = mapOf("role" to "admin", "region" to "us")
+                tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("us"))
             )
 
             println("appending...")
@@ -534,11 +541,11 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "alice", "region" to "eu")
+            tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
         )
 
         val fact2 = Fact(
@@ -547,11 +554,11 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Bob" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "bob", "region" to "us")
+            tags = mapOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
         )
 
         val fact3 = Fact(
@@ -560,11 +567,11 @@ class FactStoreTest {
                 type = "USER",
                 id = "CHARLIE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Charlie" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "charlie", "region" to "us")
+            tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
         )
 
         store.append(listOf(fact1, fact2, fact3))
@@ -574,8 +581,8 @@ class FactStoreTest {
         val bobQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("username" to "bob")
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("username") to TagValue("bob"))
                 )
             )
         )
@@ -587,8 +594,8 @@ class FactStoreTest {
         val multipleTagsQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("username" to "bob", "region" to "us")
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
                 )
             )
         )
@@ -600,8 +607,8 @@ class FactStoreTest {
         val noMatchQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("username" to "bob", "region" to "eu")
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("eu"))
                 )
             )
         )
@@ -613,8 +620,8 @@ class FactStoreTest {
         val multipleTypesQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED", "USER_DELETED"),
-                    tags = listOf("username" to "bob")
+                    types = listOf("USER_CREATED".toFactType(), "USER_DELETED".toFactType()),
+                    tags = listOf(TagKey("username") to TagValue("bob"))
                 )
             )
         )
@@ -626,8 +633,8 @@ class FactStoreTest {
         val complexQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED", "USER_DELETED"),
-                    tags = listOf("username" to "bob", "region" to "us")
+                    types = listOf("USER_CREATED".toFactType(), "USER_DELETED".toFactType()),
+                    tags = listOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
                 )
             )
         )
@@ -639,8 +646,8 @@ class FactStoreTest {
         val noMatchingTagQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("username" to "dave")
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("username") to TagValue("dave"))
                 )
             )
         )
@@ -652,8 +659,8 @@ class FactStoreTest {
         val noMatchingTypeQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_DELETED"),
-                    tags = listOf("username" to "bob")
+                    types = listOf(FactType("USER_DELETED")),
+                    tags = listOf(TagKey("username") to TagValue("bob"))
                 )
             )
         )
@@ -665,8 +672,8 @@ class FactStoreTest {
         val tagsNoFactsQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("username" to "david", "region" to "asia")
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("username") to TagValue("david"), TagKey("region") to TagValue("asia"))
                 )
             )
         )
@@ -678,8 +685,8 @@ class FactStoreTest {
         val differentTagsQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("username" to "charlie", "region" to "us")
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
                 )
             )
         )
@@ -695,31 +702,31 @@ class FactStoreTest {
         val fact1 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "ALICE"),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "alice", "region" to "eu")
+            tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
         )
 
         val fact2 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "BOB"),
-            type = "USER_UPDATED",
+            type = "USER_UPDATED".toFactType(),
             payload = """{ "username": "Bob" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "bob", "region" to "us")
+            tags = mapOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
         )
 
         val fact3 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Charlie" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "charlie", "region" to "us")
+            tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
         )
 
         store.append(listOf(fact1, fact2, fact3))
@@ -728,8 +735,8 @@ class FactStoreTest {
         val query = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED", "USER_UPDATED"),
-                    tags = listOf("username" to "alice")
+                    types = listOf("USER_CREATED".toFactType(), "USER_UPDATED".toFactType()),
+                    tags = listOf(TagKey("username") to TagValue("alice"))
                 )
             )
         )
@@ -746,31 +753,31 @@ class FactStoreTest {
         val fact1 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "ALICE"),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "alice", "region" to "eu")
+            tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
         )
 
         val fact2 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "BOB"),
-            type = "USER_UPDATED",
+            type = "USER_UPDATED".toFactType(),
             payload = """{ "username": "Bob" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "bob", "region" to "us")
+            tags = mapOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
         )
 
         val fact3 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Charlie" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "charlie", "region" to "us")
+            tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
         )
 
         store.append(listOf(fact1, fact2, fact3))
@@ -779,12 +786,12 @@ class FactStoreTest {
         val query = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED", "USER_UPDATED"),
-                    tags = listOf("username" to "bob")
+                    types = listOf("USER_CREATED".toFactType(), "USER_UPDATED".toFactType()),
+                    tags = listOf(TagKey("username") to TagValue("bob"))
                 ),
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("region" to "us")
+                    types = listOf("USER_CREATED".toFactType()),
+                    tags = listOf(TagKey("region") to TagValue("us"))
                 )
             )
         )
@@ -802,31 +809,31 @@ class FactStoreTest {
         val fact1 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "ALICE"),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "alice", "region" to "eu")
+            tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
         )
 
         val fact2 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "BOB"),
-            type = "USER_UPDATED",
+            type = "USER_UPDATED".toFactType(),
             payload = """{ "username": "Bob" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "bob", "region" to "us")
+            tags = mapOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
         )
 
         val fact3 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Charlie" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "charlie", "region" to "us")
+            tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
         )
 
         store.append(listOf(fact1, fact2, fact3))
@@ -835,12 +842,12 @@ class FactStoreTest {
         val query = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED", "USER_UPDATED"),
-                    tags = listOf("username" to "bob", "region" to "us")
+                    types = listOf("USER_CREATED".toFactType(), "USER_UPDATED".toFactType()),
+                    tags = listOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
                 ),
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("region" to "eu", "username" to "alice")
+                    types = listOf("USER_CREATED".toFactType()),
+                    tags = listOf(TagKey("region") to TagValue("eu"), TagKey("username") to TagValue("alice"))
                 )
             )
         )
@@ -858,11 +865,11 @@ class FactStoreTest {
         val fact1 = Fact(
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "ALICE"),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
-            tags = mapOf("username" to "alice", "region" to "eu")
+            tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
         )
 
         store.append(listOf(fact1))
@@ -871,8 +878,8 @@ class FactStoreTest {
         val query = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_UPDATED"),
-                    tags = listOf("username" to "bob")
+                    types = listOf(FactType("USER_UPDATED")),
+                    tags = listOf(TagKey("username") to TagValue("bob"))
                 )
             )
         )
@@ -896,13 +903,13 @@ class FactStoreTest {
                     type = "USER",
                     id = "user-$index"
                 ),
-                type = "USER_CREATED",
+                type = "USER_CREATED".toFactType(),
                 payload = """{ "username": "user$index" }""".toByteArray(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
                 tags = mapOf(
-                    "role" to tag,
-                    "region" to region
+                    TagKey("role") to TagValue(tag),
+                    TagKey("region") to TagValue(region)
                 )
             )
         }
@@ -920,13 +927,13 @@ class FactStoreTest {
                     type = "USER",
                     id = "user-${FactId.generate()}"
                 ),
-                type = "USER_CREATED",
+                type = "USER_CREATED".toFactType(),
                 payload = """{ "username": "user" }""".toByteArray(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
                 tags = mapOf(
-                    "role" to "custom",
-                    "region" to "eu"
+                    TagKey("role") to TagValue("custom"),
+                    TagKey("region") to TagValue("eu")
                 )
             )
         )
@@ -936,8 +943,8 @@ class FactStoreTest {
         val query = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("role" to "user", "region" to "us")
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("role") to TagValue("user"), TagKey("region") to TagValue("us"))
                 )
             )
         )
@@ -954,8 +961,8 @@ class FactStoreTest {
                 TagQuery(
                     listOf(
                         TagTypeItem(
-                            types = listOf("USER_CREATED"),
-                            tags = listOf("role" to "custom")
+                            types = listOf(FactType("USER_CREATED")),
+                            tags = listOf(TagKey("role") to TagValue("custom"))
                         )
                     )
                 )
@@ -965,9 +972,9 @@ class FactStoreTest {
 
         // Step 3: Verify that the result only contains facts with the expected tags
         // The number of events matching "role=user" and "region=us" should be around half of 10,000 (i.e., ~5000).
-        val expectedCount = events.count { it.tags["role"] == "user" && it.tags["region"] == "us" }
+        val expectedCount = events.count { it.tags[TagKey("role")] == TagValue("user") && it.tags[TagKey("region")] == TagValue("us") }
         assertThat(result).hasSize(expectedCount) // Ensure the correct number of matching events
-        assertThat(result).allMatch { it.tags["role"] == "user" && it.tags["region"] == "us" } // Ensure correct tags
+        assertThat(result).allMatch { it.tags[TagKey("role")] == TagValue("user") && it.tags[TagKey("region")] == TagValue("us") } // Ensure correct tags
 
         // Step 4: Optionally, print out some details to confirm the query works (only if needed)
         println("Found ${result.size} events with 'role=user' and 'region=us'.")
@@ -985,11 +992,11 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "Alice" }""".toByteArray(),
             createdAt = Instant.now(),
             tags = mapOf(
-                "user" to "ALICE",
+                TagKey("user") to TagValue("ALICE"),
             )
         )
 
@@ -997,8 +1004,8 @@ class FactStoreTest {
         val tagQuery = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("user" to "ALICE"),
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("user") to TagValue("ALICE")),
                 )
             )
         )
@@ -1022,11 +1029,11 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_LOCKED",
+            type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "ALICE" }""".toByteArray(),
             createdAt = Instant.now(),
             tags = mapOf(
-                "user" to "ALICE",
+                TagKey("user") to TagValue("ALICE"),
             )
         )
 
@@ -1063,19 +1070,19 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_CREATED",
+            type = "USER_CREATED".toFactType(),
             payload = """{ "username": "BOB" }""".toByteArray(),
             createdAt = Instant.now(),
             tags = mapOf(
-                "user" to "BOB",
+                TagKey("user") to TagValue("BOB"),
             )
         )
 
         val tagQuery2 = TagQuery(
             queryItems = listOf(
                 TagTypeItem(
-                    types = listOf("USER_CREATED"),
-                    tags = listOf("user" to "BOB"),
+                    types = listOf(FactType("USER_CREATED")),
+                    tags = listOf(TagKey("user") to TagValue("BOB")),
                 )
             )
         )
@@ -1098,11 +1105,11 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_LOCKED",
+            type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "BOB" }""".toByteArray(),
             createdAt = Instant.now(),
             tags = mapOf(
-                "user" to "BOB",
+                TagKey("user") to TagValue("BOB"),
             )
         )
 
@@ -1141,7 +1148,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "BOB",
             ),
-            type = "USER_LOCKED",
+            type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "BOB" }""".toByteArray(),
             createdAt = Instant.now(),
             tags = emptyMap()
@@ -1153,7 +1160,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "ALICE",
             ),
-            type = "USER_LOCKED",
+            type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "ALICE" }""".toByteArray(),
             createdAt = Instant.now(),
             tags = emptyMap()
@@ -1184,7 +1191,7 @@ class FactStoreTest {
                 type = "USER",
                 id = "DOMI",
             ),
-            type = "USER_LOCKED",
+            type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "DOMI" }""".toByteArray(),
             createdAt = Instant.now(),
             tags = emptyMap()
@@ -1225,7 +1232,7 @@ class FactStoreTest {
                 type = "TEST_TYPE",
                 id = "TEST_ID",
             ),
-            type = "TEST_FACT_TYPE",
+            type = "TEST_FACT_TYPE".toFactType(),
             payload = """DATA""".toByteArray(),
             createdAt = Instant.now(),
             tags = emptyMap()

--- a/factstore-specification/src/main/kotlin/org/factstore/core/Fact.kt
+++ b/factstore-specification/src/main/kotlin/org/factstore/core/Fact.kt
@@ -25,12 +25,12 @@ import java.util.*
  */
 data class Fact(
     val id: FactId,
-    val type: String,
+    val type: FactType,
     val payload: ByteArray,
     val subjectRef: SubjectRef,
     val createdAt: Instant,
     val metadata: Map<String, String> = emptyMap(),
-    val tags: Map<String, String> = emptyMap(),
+    val tags: Map<TagKey, TagValue> = emptyMap(),
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -101,6 +101,70 @@ value class FactId(val uuid: UUID) {
 }
 
 /**
+ * Identifies the logical type of a [Fact].
+ *
+ * A [FactType] represents the semantic classification of a fact, such as
+ * `"OrderCreated"` or `"PaymentAuthorized"`. Fact types are used for
+ * categorization, querying, and downstream processing, but FactStore does
+ * not impose any domain-specific semantics or schema constraints on them.
+ *
+ * The value is treated as an opaque, non-blank identifier. Naming conventions
+ * and lifecycle management of fact types are intentionally left to clients.
+ *
+ * @property value the textual representation of the fact type
+ *
+ * @author Domenic Cassisi
+ */
+@JvmInline
+value class FactType(val value: String) {
+    init {
+        require(value.isNotBlank()) { "Type must not be blank" }
+    }
+}
+
+/**
+ * Identifies a tag key used to classify or annotate facts.
+ *
+ * A [TagKey] represents the name of a tag, such as `"region"`, `"tenant"`,
+ * or `"archived"`. Tag keys are used in combination with [TagValue]s to
+ * support flexible querying and secondary indexing.
+ *
+ * Tag keys are required to be non-blank. No additional constraints or
+ * naming conventions are enforced by FactStore.
+ *
+ * @property value the textual representation of the tag key
+ *
+ * @author Domenic Cassisi
+ */
+@JvmInline
+value class TagKey(val value: String) {
+    init {
+        require(value.isNotBlank()) { "TagKey must not be blank" }
+    }
+}
+
+/**
+ * Represents the value associated with a [TagKey].
+ *
+ * A [TagValue] may either carry a meaningful value (for example `"eu"` or
+ * `"v2"`) or be empty to indicate presence-only semantics. Empty values are
+ * commonly used to express boolean-like or classificatory tags, such as
+ * `"archived"`.
+ *
+ * FactStore does not impose any interpretation on tag values; their meaning
+ * is entirely defined by the client.
+ *
+ * @property value the textual representation of the tag value, which may be empty
+ *
+ * @author Domenic Cassisi
+ */
+@JvmInline
+value class TagValue(val value: String)
+
+/**
  * Converts a [UUID] to a [FactId].
  */
 fun UUID.toFactId() = FactId(this)
+fun String.toFactType() = FactType(this)
+fun String.toTagKey() = TagKey(this)
+fun String.toTagValue() = TagValue(this)

--- a/factstore-specification/src/main/kotlin/org/factstore/core/FactFinder.kt
+++ b/factstore-specification/src/main/kotlin/org/factstore/core/FactFinder.kt
@@ -56,7 +56,7 @@ interface FactFinder {
      * @param tags the list of tag key-value pairs
      * @return the list of facts matching the specified tags
      */
-    suspend fun findByTags(tags: List<Pair<String, String>>): List<Fact>
+    suspend fun findByTags(tags: List<Pair<TagKey, TagValue>>): List<Fact>
 
     /**
      * Finds all facts that match the given tag query.

--- a/factstore-specification/src/main/kotlin/org/factstore/core/TagQuery.kt
+++ b/factstore-specification/src/main/kotlin/org/factstore/core/TagQuery.kt
@@ -25,8 +25,8 @@ sealed interface TagQueryItem
  * @author Domenic Cassisi
  */
 data class TagTypeItem(
-    val types: List<String>,
-    val tags: List<Pair<String, String>>
+    val types: List<FactType>,
+    val tags: List<Pair<TagKey, TagValue>>
 ) : TagQueryItem {
     init {
         require(types.isNotEmpty() && tags.isNotEmpty()) {
@@ -48,7 +48,7 @@ data class TagTypeItem(
  * @author Domenic Cassisi
  */
 data class TagOnlyQueryItem(
-    val tags: List<Pair<String, String>>
+    val tags: List<Pair<TagKey, TagValue>>
 ) : TagQueryItem {
     init {
         require(tags.isNotEmpty()) { "Tags must be defined!" }

--- a/factstore-specification/src/test/kotlin/org/factstore/core/AppendRequestTest.kt
+++ b/factstore-specification/src/test/kotlin/org/factstore/core/AppendRequestTest.kt
@@ -15,7 +15,7 @@ class AppendRequestTest {
                 type = "TEST_TYPE",
                 id = "TEST_ID",
             ),
-            type = "TEST_FACT_TYPE",
+            type = FactType("TEST_FACT_TYPE"),
             payload = """DATA""".toByteArray(),
             createdAt = Instant.now(),
             tags = emptyMap()

--- a/factstore-specification/src/test/kotlin/org/factstore/core/FactQueryTest.kt
+++ b/factstore-specification/src/test/kotlin/org/factstore/core/FactQueryTest.kt
@@ -9,8 +9,8 @@ class FactQueryTest {
 
     @Test
     fun `TagTypeItem constructs successfully with valid types and tags`() {
-        val types = listOf("person", "event")
-        val tags = listOf("key1" to "value1", "key2" to "value2")
+        val types = listOf(FactType("person"), FactType("event"))
+        val tags = listOf(TagKey("key1") to TagValue("value1"), TagKey("key2") to TagValue("value2"))
 
         val item = TagTypeItem(types, tags)
 
@@ -20,8 +20,8 @@ class FactQueryTest {
 
     @Test
     fun `TagTypeItem fails when types is empty`() {
-        val types = emptyList<String>()
-        val tags = listOf("key" to "value")
+        val types = emptyList<FactType>()
+        val tags = listOf(TagKey("key") to TagValue("value"))
 
         val ex = assertThrows<IllegalArgumentException> {
             TagTypeItem(types, tags)
@@ -31,8 +31,8 @@ class FactQueryTest {
 
     @Test
     fun `TagTypeItem fails when tags is empty`() {
-        val types = listOf("person")
-        val tags = emptyList<Pair<String, String>>()
+        val types = listOf(FactType("person"))
+        val tags = emptyList<Pair<TagKey, TagValue>>()
 
         val ex = assertThrows<IllegalArgumentException> {
             TagTypeItem(types, tags)
@@ -52,7 +52,7 @@ class FactQueryTest {
 
     @Test
     fun `TagOnlyQueryItem constructs successfully with tags`() {
-        val tags = listOf("country" to "US")
+        val tags = listOf(TagKey("country") to TagValue("US"))
 
         val item = TagOnlyQueryItem(tags)
 
@@ -71,8 +71,8 @@ class FactQueryTest {
 
     @Test
     fun `TagQuery constructs successfully with mixed query items`() {
-        val item1 = TagOnlyQueryItem(listOf("k1" to "v1"))
-        val item2 = TagTypeItem(listOf("type1"), listOf("k2" to "v2"))
+        val item1 = TagOnlyQueryItem(listOf(TagKey("k1") to TagValue("v1")))
+        val item2 = TagTypeItem(listOf(FactType("type1")), listOf(TagKey("k2") to TagValue("v2")))
 
         val query = TagQuery(listOf(item1, item2))
 


### PR DESCRIPTION
In order to make the code more explicit and robust, and avoid ambiguity, we want to introduce explicit value types for:
- `TagKey`
- `TagValue`
- `FactType`