### PR TITLE
Introduce FactPayload type where payload-related data is gathered

### DIFF
--- a/factstore-avro/src/main/kotlin/org/factstore/avro/AvroFdbStore.kt
+++ b/factstore-avro/src/main/kotlin/org/factstore/avro/AvroFdbStore.kt
@@ -88,7 +88,7 @@ object FactRegistry {
     fun fromEnvelope(fact: Fact): Any {
         val descriptor = byType[fact.type.value] ?: error("Unknown fact type ${fact.type}")
         val serde = (descriptor as FactDescriptor<Any>).serializer
-        return serde.deserialize(fact.payload)
+        return serde.deserialize(fact.payload.data)
     }
 
     fun toEnvelope(fact: Any): Fact {
@@ -127,7 +127,7 @@ object FactRegistry {
         val fact = Fact(
             id = FactId.generate(),
             type = org.factstore.core.FactType(factType),
-            payload = factSerde.serialize(fact),
+            payload = FactPayload(factSerde.serialize(fact)),
             subjectRef = SubjectRef(
                 type = subjectType,
                 id = subjectId

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactStore.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFactStore.kt
@@ -192,7 +192,11 @@ internal fun Fact.toSerializableFdbFact() = SerializableFdbFact(
     timeNanos = createdAt.nano,
     metadata = metadata,
     tags = tags.entries.associate { it.key.value to it.value.value },
-    payload = payload
+    payload = SerializableFactPayload(
+        data = payload.data,
+        format = payload.format?.value,
+        schema = payload.schema?.value
+    )
 )
 
 internal fun SerializableFdbFact.encodeToByteArray() = Avro.encodeToByteArray(this)
@@ -202,7 +206,11 @@ internal fun ByteArray.toSerializableFdbFact() = Avro.decodeFromByteArray<Serial
 internal fun SerializableFdbFact.toFact() = Fact(
     id = FactId(id),
     type = FactType(type),
-    payload = payload,
+    payload = FactPayload(
+        data = payload.data,
+        format = payload.format?.toPayloadFormat(),
+        schema = payload.format?.toPayloadSchemaRef()
+    ),
     subjectRef = SubjectRef(
         type = subjectType,
         id = subjectId

--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/SerializableFdbFact.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/SerializableFdbFact.kt
@@ -15,37 +15,32 @@ data class SerializableFdbFact(
     val timeNanos: Int,
     val metadata: Map<String, String> = emptyMap(),
     val tags: Map<String, String> = emptyMap(),
-    val payload: ByteArray,
+    val payload: SerializableFactPayload,
+)
+
+@Serializable
+data class SerializableFactPayload(
+    val data: ByteArray,
+    val format: String?,
+    val schema: String?,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as SerializableFdbFact
+        other as SerializableFactPayload
 
-        if (id != other.id) return false
-        if (type != other.type) return false
-        if (subjectType != other.subjectType) return false
-        if (subjectId != other.subjectId) return false
-        if (timeEpochSeconds != other.timeEpochSeconds) return false
-        if (timeNanos != other.timeNanos) return false
-        if (metadata != other.metadata) return false
-        if (tags != other.tags) return false
-        if (!payload.contentEquals(other.payload)) return false
+        if (!data.contentEquals(other.data)) return false
+        if (format != other.format) return false
+        if (schema != other.schema) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = id.hashCode()
-        result = 31 * result + type.hashCode()
-        result = 31 * result + subjectType.hashCode()
-        result = 31 * result + subjectId.hashCode()
-        result = 31 * result + timeEpochSeconds.hashCode()
-        result = 31 * result + timeNanos.hashCode()
-        result = 31 * result + metadata.hashCode()
-        result = 31 * result + tags.hashCode()
-        result = 31 * result + payload.contentHashCode()
+        var result = data.contentHashCode()
+        result = 31 * result + format.hashCode()
+        result = 31 * result + schema.hashCode()
         return result
     }
 }

--- a/factstore-foundationdb/src/test/kotlin/org/factstore/foundationdb/FactStoreTest.kt
+++ b/factstore-foundationdb/src/test/kotlin/org/factstore/foundationdb/FactStoreTest.kt
@@ -66,7 +66,7 @@ class FactStoreTest {
     @Test
     fun testSimpleAppend(): Unit = runBlocking {
         val id = FactId.generate()
-        val payload = """ { "username": "Peter" } """.toByteArray()
+        val payload = """ { "username": "Peter" } """.toFactPayload()
         val createdAt = Instant.now()
 
         val fact = Fact(
@@ -107,7 +107,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = now.minusSeconds(60) // 1 minute ago
         )
 
@@ -118,7 +118,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_UPDATED".toFactType(),
-            payload = """{ "username": "Alice", "status": "active" }""".toByteArray(),
+            payload = """{ "username": "Alice", "status": "active" }""".toFactPayload(),
             createdAt = now
         )
 
@@ -129,7 +129,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_DELETED".toFactType(),
-            payload = """{ "username": "Bob" }""".toByteArray(),
+            payload = """{ "username": "Bob" }""".toFactPayload(),
             createdAt = now.plusSeconds(60) // 1 minute in the future
         )
 
@@ -157,7 +157,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -188,7 +188,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_LOCKED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -242,7 +242,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -253,7 +253,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "BOB" }""".toByteArray(),
+            payload = """{ "username": "BOB" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -264,7 +264,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_LOCKED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -299,7 +299,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -310,7 +310,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "BOB" }""".toByteArray(),
+            payload = """{ "username": "BOB" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -321,7 +321,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_LOCKED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -352,7 +352,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = mapOf("test" to "123", "loc" to "world")
         )
@@ -364,7 +364,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "BOB" }""".toByteArray(),
+            payload = """{ "username": "BOB" }""".toFactPayload(),
             createdAt = Instant.now()
         )
 
@@ -385,7 +385,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("eu"))
@@ -398,7 +398,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Bob" }""".toByteArray(),
+            payload = """{ "username": "Bob" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("role") to TagValue("user"), TagKey("region") to TagValue("us"))
@@ -411,7 +411,7 @@ class FactStoreTest {
                 id = "CHARLIE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Charlie" }""".toByteArray(),
+            payload = """{ "username": "Charlie" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("us"))
@@ -473,7 +473,7 @@ class FactStoreTest {
                     id = "ALICE",
                 ),
                 type = "USER_CREATED".toFactType(),
-                payload = """{ "username": "Alice" }""".toByteArray(),
+                payload = """{ "username": "Alice" }""".toFactPayload(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
                 tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("eu"))
@@ -486,7 +486,7 @@ class FactStoreTest {
                     id = "BOB",
                 ),
                 type = "USER_CREATED".toFactType(),
-                payload = """{ "username": "Bob" }""".toByteArray(),
+                payload = """{ "username": "Bob" }""".toFactPayload(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
                 tags = mapOf(TagKey("role") to TagValue("user"), TagKey("region") to TagValue("us"))
@@ -499,7 +499,7 @@ class FactStoreTest {
                     id = "CHARLIE",
                 ),
                 type = "USER_CREATED".toFactType(),
-                payload = """{ "username": "Charlie" }""".toByteArray(),
+                payload = """{ "username": "Charlie" }""".toFactPayload(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
                 tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("us"))
@@ -542,7 +542,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
@@ -555,7 +555,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Bob" }""".toByteArray(),
+            payload = """{ "username": "Bob" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
@@ -568,7 +568,7 @@ class FactStoreTest {
                 id = "CHARLIE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Charlie" }""".toByteArray(),
+            payload = """{ "username": "Charlie" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
@@ -703,7 +703,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "ALICE"),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
@@ -713,7 +713,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "BOB"),
             type = "USER_UPDATED".toFactType(),
-            payload = """{ "username": "Bob" }""".toByteArray(),
+            payload = """{ "username": "Bob" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
@@ -723,7 +723,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Charlie" }""".toByteArray(),
+            payload = """{ "username": "Charlie" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
@@ -754,7 +754,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "ALICE"),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
@@ -764,7 +764,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "BOB"),
             type = "USER_UPDATED".toFactType(),
-            payload = """{ "username": "Bob" }""".toByteArray(),
+            payload = """{ "username": "Bob" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
@@ -774,7 +774,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Charlie" }""".toByteArray(),
+            payload = """{ "username": "Charlie" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
@@ -810,7 +810,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "ALICE"),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
@@ -820,7 +820,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "BOB"),
             type = "USER_UPDATED".toFactType(),
-            payload = """{ "username": "Bob" }""".toByteArray(),
+            payload = """{ "username": "Bob" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("bob"), TagKey("region") to TagValue("us"))
@@ -830,7 +830,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Charlie" }""".toByteArray(),
+            payload = """{ "username": "Charlie" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
@@ -866,7 +866,7 @@ class FactStoreTest {
             id = FactId.generate(),
             subjectRef = SubjectRef(type = "USER", id = "ALICE"),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now(),
             metadata = emptyMap(),
             tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
@@ -904,7 +904,7 @@ class FactStoreTest {
                     id = "user-$index"
                 ),
                 type = "USER_CREATED".toFactType(),
-                payload = """{ "username": "user$index" }""".toByteArray(),
+                payload = """{ "username": "user$index" }""".toFactPayload(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
                 tags = mapOf(
@@ -928,7 +928,7 @@ class FactStoreTest {
                     id = "user-${FactId.generate()}"
                 ),
                 type = "USER_CREATED".toFactType(),
-                payload = """{ "username": "user" }""".toByteArray(),
+                payload = """{ "username": "user" }""".toFactPayload(),
                 createdAt = Instant.now(),
                 metadata = emptyMap(),
                 tags = mapOf(
@@ -993,7 +993,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "Alice" }""".toByteArray(),
+            payload = """{ "username": "Alice" }""".toFactPayload(),
             createdAt = Instant.now(),
             tags = mapOf(
                 TagKey("user") to TagValue("ALICE"),
@@ -1030,7 +1030,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_LOCKED".toFactType(),
-            payload = """{ "username": "ALICE" }""".toByteArray(),
+            payload = """{ "username": "ALICE" }""".toFactPayload(),
             createdAt = Instant.now(),
             tags = mapOf(
                 TagKey("user") to TagValue("ALICE"),
@@ -1071,7 +1071,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_CREATED".toFactType(),
-            payload = """{ "username": "BOB" }""".toByteArray(),
+            payload = """{ "username": "BOB" }""".toFactPayload(),
             createdAt = Instant.now(),
             tags = mapOf(
                 TagKey("user") to TagValue("BOB"),
@@ -1106,7 +1106,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_LOCKED".toFactType(),
-            payload = """{ "username": "BOB" }""".toByteArray(),
+            payload = """{ "username": "BOB" }""".toFactPayload(),
             createdAt = Instant.now(),
             tags = mapOf(
                 TagKey("user") to TagValue("BOB"),
@@ -1149,7 +1149,7 @@ class FactStoreTest {
                 id = "BOB",
             ),
             type = "USER_LOCKED".toFactType(),
-            payload = """{ "username": "BOB" }""".toByteArray(),
+            payload = """{ "username": "BOB" }""".toFactPayload(),
             createdAt = Instant.now(),
             tags = emptyMap()
         )
@@ -1161,7 +1161,7 @@ class FactStoreTest {
                 id = "ALICE",
             ),
             type = "USER_LOCKED".toFactType(),
-            payload = """{ "username": "ALICE" }""".toByteArray(),
+            payload = """{ "username": "ALICE" }""".toFactPayload(),
             createdAt = Instant.now(),
             tags = emptyMap()
         )
@@ -1192,7 +1192,7 @@ class FactStoreTest {
                 id = "DOMI",
             ),
             type = "USER_LOCKED".toFactType(),
-            payload = """{ "username": "DOMI" }""".toByteArray(),
+            payload = """{ "username": "DOMI" }""".toFactPayload(),
             createdAt = Instant.now(),
             tags = emptyMap()
         )
@@ -1233,7 +1233,7 @@ class FactStoreTest {
                 id = "TEST_ID",
             ),
             type = "TEST_FACT_TYPE".toFactType(),
-            payload = """DATA""".toByteArray(),
+            payload = """DATA""".toFactPayload(),
             createdAt = Instant.now(),
             tags = emptyMap()
         )

--- a/factstore-specification/src/test/kotlin/org/factstore/core/AppendRequestTest.kt
+++ b/factstore-specification/src/test/kotlin/org/factstore/core/AppendRequestTest.kt
@@ -16,7 +16,7 @@ class AppendRequestTest {
                 id = "TEST_ID",
             ),
             type = FactType("TEST_FACT_TYPE"),
-            payload = """DATA""".toByteArray(),
+            payload = """DATA""".toFactPayload(),
             createdAt = Instant.now(),
             tags = emptyMap()
         )


### PR DESCRIPTION
This development introduces an explicit `FactPayload` type that gathers payload-related data, including the data itself (as byte array), a schema reference, and the payload format (avro, XML, ...). Later, we can add more fields like compression, checksums etc.