### PR TITLE
#76 Store fact payloads in global order stream for efficient range scans

### DIFF
--- a/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFact.kt
+++ b/factstore-foundationdb/src/main/kotlin/org/factstore/foundationdb/FdbFact.kt
@@ -1,9 +1,8 @@
 package org.factstore.foundationdb
 
-import com.apple.foundationdb.tuple.Tuple
 import org.factstore.core.Fact
 
 data class FdbFact(
     val fact: Fact,
-    val positionTuple: Tuple
+    val factPosition: FactPosition
 )


### PR DESCRIPTION
This development refactors the subspace design.
The global fact store subspace with all facts contains the whole fact payload. All other subspaces contain the fact position for ordering in the key and the fact ID in the value.

In addition, the separate index tuple entry was replaced by the user version that can be passed as part of the versionstamp. This makes the keys shorter and the solution more performant. 