### PR TITLE
Initial Factstore Factory

### DIFF
--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStore.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStore.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
 import io.factstore.core.*
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 const val FACT_STORE = "fact-store"
@@ -199,6 +200,7 @@ typealias FactPosition = Versionstamp
 
 fun Tuple.getFirstAsFactId(): FactId = getUUID(0).toFactId()
 fun Tuple.getLastAsFactPosition(): FactPosition = getVersionstamp(size() - 1)
+fun Tuple.getLastAsUuid(): UUID = getUUID(size() - 1)
 
 fun Fact.toSerializableFdbFact() = SerializableFdbFact(
     id = id.uuid,

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStoreFactory.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStoreFactory.kt
@@ -1,0 +1,63 @@
+package io.factstore.foundationdb
+
+import com.apple.foundationdb.directory.DirectoryLayer
+import com.apple.foundationdb.tuple.Tuple
+import io.factstore.core.CreateFactStoreRequest
+import io.factstore.core.CreateFactStoreResult
+import io.factstore.core.FactStoreFactory
+import io.factstore.core.FactStoreId
+import kotlinx.coroutines.future.await
+import java.time.Instant
+import java.time.temporal.ChronoUnit.SECONDS
+
+class FdbFactStoreFactory(
+    private val context: FoundationDBFactStoreContext
+) : FactStoreFactory {
+
+    companion object {
+        const val FACTSTORE_METADATA_NAME = "factstore-metadata"
+        const val BY_ID = "by-id"
+        const val BY_NAME = "by-name"
+    }
+
+    private val factStoreDirectory = DirectoryLayer
+        .getDefault()
+        .createOrOpen(context.database, listOf(FACTSTORE_METADATA_NAME))
+        .get()
+
+    private val byIdSubspace =
+        factStoreDirectory.subspace(Tuple.from(BY_ID))
+
+    private val byNameSubspace =
+        factStoreDirectory.subspace(Tuple.from(BY_NAME))
+
+    override suspend fun handle(request: CreateFactStoreRequest): CreateFactStoreResult {
+        val factStoreId = FactStoreId.generate()
+        val createdAt = Instant.now().truncatedTo(SECONDS)
+
+        // create...
+        return context.database.runAsync { tr ->
+            // check if name is already taken
+            val nameKey = byNameSubspace.pack(Tuple.from(request.factStoreName.value))
+            tr.get(nameKey).thenApply { valueBytes ->
+                if (valueBytes != null) {
+                    // value bytes are not null, hence name is already taken
+                    return@thenApply CreateFactStoreResult.NameAlreadyExists(request.factStoreName)
+                } else {
+                    // name is available
+                    // go ahead and create the fact store
+
+                    // write name to Id lookup index
+                    tr[nameKey] = Tuple.from(factStoreId.uuid).pack()
+
+                    // write id to metadata
+                    val idKey = byIdSubspace.pack(Tuple.from(factStoreId.uuid))
+                    tr[idKey] = Tuple.from(request.factStoreName.value, createdAt.epochSecond).pack()
+
+                    CreateFactStoreResult.Created(factStoreId)
+                }
+            }
+        }.await()
+    }
+
+}

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStoreFinder.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStoreFinder.kt
@@ -1,0 +1,65 @@
+package io.factstore.foundationdb
+
+import com.apple.foundationdb.directory.DirectoryLayer
+import com.apple.foundationdb.tuple.Tuple
+import io.factstore.core.FactStoreFinder
+import io.factstore.core.FactStoreId
+import io.factstore.core.FactStoreMetadata
+import io.factstore.core.FactStoreName
+import kotlinx.coroutines.future.await
+import java.time.Instant
+
+class FdbFactStoreFinder(
+    context: FoundationDBFactStoreContext
+) : FactStoreFinder {
+
+    companion object {
+        const val FACTSTORE_METADATA_NAME = "factstore-metadata"
+        const val BY_ID = "by-id"
+        const val BY_NAME = "by-name"
+    }
+
+    private val factStoreDirectory = DirectoryLayer
+        .getDefault()
+        .createOrOpen(context.database, listOf(FACTSTORE_METADATA_NAME))
+        .get()
+
+    private val byIdSubspace =
+        factStoreDirectory.subspace(Tuple.from(BY_ID))
+
+    private val byNameSubspace =
+        factStoreDirectory.subspace(Tuple.from(BY_NAME))
+
+    private val database = context.database
+
+    override suspend fun listAll(): List<FactStoreMetadata> {
+        return database.readAsync { tr ->
+            tr.getRange(byIdSubspace.range()).asList()
+                .thenApply { kvList ->
+                    kvList.map { kv ->
+                        val keyTuple = byIdSubspace.unpack(kv.key)
+                        val valueTuple = Tuple.fromBytes(kv.value)
+
+                        val id = keyTuple.getLastAsUuid()
+                        val name = valueTuple.getString(0)
+                        val createdAtEpochSecond = valueTuple.getLong(1)
+
+                        FactStoreMetadata(
+                            id = FactStoreId(id),
+                            name = FactStoreName(name),
+                            createdAt = Instant.ofEpochSecond(createdAtEpochSecond)
+                        )
+                    }
+                }
+        }.await()
+    }
+
+    override suspend fun existsByName(name: FactStoreName): Boolean {
+        return database.readAsync { tr ->
+            val nameToIdIndexKey = byNameSubspace.pack(Tuple.from(name.value))
+            tr[nameToIdIndexKey].thenApply { valueBytes ->
+                valueBytes != null
+            }
+        }.await()
+    }
+}

--- a/factstore-foundationdb/src/test/kotlin/io/factstore/foundationdb/FactStoreFactoryTest.kt
+++ b/factstore-foundationdb/src/test/kotlin/io/factstore/foundationdb/FactStoreFactoryTest.kt
@@ -1,0 +1,86 @@
+package io.factstore.foundationdb
+
+import com.apple.foundationdb.FDB
+import earth.adi.testcontainers.containers.FoundationDBContainer
+import io.factstore.core.*
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+@TestInstance(PER_CLASS)
+@Testcontainers
+class FactStoreFactoryTest {
+
+    companion object {
+
+        lateinit var factory: FactStoreFactory
+        lateinit var finder: FactStoreFinder
+        lateinit var resetHelper: FdbFactStoreResetHelper
+        lateinit var clusterFilePath: String
+
+        @Container
+        val testFdbCluster = FoundationDBContainer(DockerImageName.parse("foundationdb/foundationdb:$FDB_VERSION"))
+
+        @JvmStatic
+        @BeforeAll
+        fun setupFDB() = runBlocking {
+            FDB.selectAPIVersion(FDB_API_VERSION)
+            clusterFilePath = testFdbCluster.clusterFilePath
+            val db = FDB.instance().open(clusterFilePath)
+            val context = FoundationDBFactStoreContext(db)
+            factory = FdbFactStoreFactory(context)
+            finder = FdbFactStoreFinder(context)
+            resetHelper = FdbFactStoreResetHelper(db)
+        }
+
+    }
+
+    @BeforeEach
+    fun clearEventStore() {
+        resetHelper.reset()
+    }
+
+    @Test
+    fun testCreateFactStore(): Unit = runBlocking {
+        val name = FactStoreName("test")
+        val request = CreateFactStoreRequest(name)
+
+        val result = factory.handle(request)
+
+        assertThat(result)
+            .isNotNull()
+            .isInstanceOf(CreateFactStoreResult.Created::class.java)
+
+        // creating another fact store with the same name should be rejected
+        val secondResult = factory.handle(request)
+
+        assertThat(secondResult)
+            .isNotNull()
+            .isInstanceOf(CreateFactStoreResult.NameAlreadyExists::class.java)
+
+        // creating another fact store with a different name should work
+
+        val anotherName = FactStoreName("another-store")
+        val anotherRequest = CreateFactStoreRequest(anotherName)
+
+        val thirdResult = factory.handle(anotherRequest)
+
+        assertThat(thirdResult)
+            .isNotNull()
+            .isInstanceOf(CreateFactStoreResult.Created::class.java)
+
+        assertThat(finder.existsByName(name)).isTrue()
+        assertThat(finder.existsByName(anotherName)).isTrue()
+        assertThat(finder.existsByName(FactStoreName("non-existing"))).isFalse()
+
+        assertThat(finder.listAll()).size().isEqualTo(2)
+    }
+
+}

--- a/factstore-server/build.gradle.kts
+++ b/factstore-server/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation("io.quarkus:quarkus-arc")
     implementation("io.quarkus:quarkus-config-yaml")
     implementation("io.quarkus:quarkus-hibernate-validator")
+    implementation("io.quarkus:quarkus-smallrye-openapi")
 
     // factstore libs
     implementation(project(":factstore-specification"))

--- a/factstore-server/scripts/curl-samples/simple-append.sh
+++ b/factstore-server/scripts/curl-samples/simple-append.sh
@@ -1,0 +1,25 @@
+!#/bin/sh
+curl -X 'POST' \
+  'http://localhost:8080/api/v1/stores/test/facts' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+   "facts":[
+      {
+         "type":"UserCreated",
+         "subjectRef":{
+            "type":"user",
+            "id":"user-3"
+         },
+         "payload":{
+            "data":"SGVsbG8gd29ybGQ="
+         },
+         "metadata":{
+
+         },
+         "tags":{
+            "vu":"bd9095f2-5494-4283-8511-9cacd3612a90"
+         }
+      }
+   ]
+}'

--- a/factstore-server/src/main/kotlin/io/factstore/server/FactStoreFactoryProducer.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/FactStoreFactoryProducer.kt
@@ -1,0 +1,19 @@
+package io.factstore.server
+
+import io.factstore.core.FactStoreFactory
+import io.factstore.foundationdb.FdbFactStoreFactory
+import io.factstore.foundationdb.FoundationDBFactStoreContext
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+
+@ApplicationScoped
+class FactStoreFactoryProducer {
+
+    @Produces
+    @ApplicationScoped
+    fun factStoreFactory(
+        foundationDBFactStoreContext: FoundationDBFactStoreContext
+    ): FactStoreFactory =
+        FdbFactStoreFactory(foundationDBFactStoreContext)
+
+}

--- a/factstore-server/src/main/kotlin/io/factstore/server/FactStoreFinderProducer.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/FactStoreFinderProducer.kt
@@ -1,0 +1,18 @@
+package io.factstore.server
+
+import io.factstore.core.FactStoreFinder
+import io.factstore.foundationdb.FdbFactStoreFinder
+import io.factstore.foundationdb.FoundationDBFactStoreContext
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.Produces
+
+@ApplicationScoped
+class FactStoreFinderProducer {
+
+    @Produces
+    @ApplicationScoped
+    fun factStoreFinder(context: FoundationDBFactStoreContext): FactStoreFinder {
+        return FdbFactStoreFinder(context)
+    }
+
+}

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/FactStoreResource.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/FactStoreResource.kt
@@ -1,0 +1,75 @@
+package io.factstore.server.http
+
+import io.factstore.core.CreateFactStoreRequest
+import io.factstore.core.CreateFactStoreResult
+import io.factstore.core.FactStoreFactory
+import io.factstore.core.FactStoreFinder
+import io.factstore.core.FactStoreName
+import jakarta.validation.Valid
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HEAD
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType.APPLICATION_JSON
+import jakarta.ws.rs.core.Response
+
+@Path("/v1/stores")
+class FactStoreResource(
+    private val factory: FactStoreFactory,
+    private val finder: FactStoreFinder
+) {
+
+    @POST
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    suspend fun createFactStore(
+        @Valid request: CreateFactStoreHttpRequest
+    ): Response = factory
+        .handle(CreateFactStoreRequest(FactStoreName(request.name)))
+        .toResponse()
+
+    private fun CreateFactStoreResult.toResponse(): Response {
+        return when (this) {
+            is CreateFactStoreResult.Created -> Response
+                .status(Response.Status.CREATED)
+                .entity(id.uuid)
+                .build()
+            is CreateFactStoreResult.NameAlreadyExists -> Response
+                .status(Response.Status.CONFLICT)
+                .entity("A fact store with the name '${factStoreName}' already exists.")
+                .build()
+        }
+    }
+
+    @HEAD
+    @Path("/{name}")
+    suspend fun factStoreExists(
+        @PathParam("name") name: String
+    ): Response {
+        finder.existsByName(FactStoreName(name)).let { exists ->
+            return if (exists) {
+                Response.ok().build()
+            } else {
+                Response.status(Response.Status.NOT_FOUND).build()
+            }
+        }
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    suspend fun listFactStores(): Response {
+        finder.listAll().let { factStores ->
+            val response = factStores.map { factStore ->
+                FactStoreMetadataHttp(
+                    id = factStore.id.uuid,
+                    name = factStore.name.value,
+                    createdAt = factStore.createdAt
+                )
+            }
+            return Response.ok(response).build()
+        }
+    }
+}

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/api.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/api.kt
@@ -102,3 +102,13 @@ data class SubjectRefHttp(
     val type: String,
     val id: String
 )
+
+data class CreateFactStoreHttpRequest(
+    val name: String
+)
+
+data class FactStoreMetadataHttp(
+    val id: UUID,
+    val name: String,
+    val createdAt: Instant
+)

--- a/factstore-specification/src/main/kotlin/io/factstore/core/CreateFactStoreRequest.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/CreateFactStoreRequest.kt
@@ -1,0 +1,5 @@
+package io.factstore.core
+
+data class CreateFactStoreRequest(
+    val factStoreName: FactStoreName,
+)

--- a/factstore-specification/src/main/kotlin/io/factstore/core/CreateFactStoreResult.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/CreateFactStoreResult.kt
@@ -1,0 +1,8 @@
+package io.factstore.core
+
+sealed interface CreateFactStoreResult {
+
+    data class Created(val id: FactStoreId) : CreateFactStoreResult
+    data class NameAlreadyExists(val factStoreName: FactStoreName) : CreateFactStoreResult
+
+}

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreFactory.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreFactory.kt
@@ -1,0 +1,7 @@
+package io.factstore.core
+
+interface FactStoreFactory {
+
+    suspend fun handle(request: CreateFactStoreRequest): CreateFactStoreResult
+
+}

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreFinder.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreFinder.kt
@@ -1,0 +1,9 @@
+package io.factstore.core
+
+interface FactStoreFinder {
+
+    suspend fun listAll(): List<FactStoreMetadata>
+
+    suspend fun existsByName(name: FactStoreName): Boolean
+
+}

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreId.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreId.kt
@@ -1,0 +1,14 @@
+package io.factstore.core
+
+import java.util.UUID
+
+@JvmInline
+value class FactStoreId(val uuid: UUID) {
+
+    companion object {
+
+        fun generate() = FactStoreId(UUID.randomUUID())
+
+    }
+
+}

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreMetadata.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreMetadata.kt
@@ -1,0 +1,9 @@
+package io.factstore.core
+
+import java.time.Instant
+
+data class FactStoreMetadata(
+    val id: FactStoreId,
+    val name: FactStoreName,
+    val createdAt: Instant,
+)

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreName.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactStoreName.kt
@@ -1,0 +1,17 @@
+package io.factstore.core
+
+@JvmInline
+value class FactStoreName(val value: String) {
+
+    companion object {
+        const val MAX_LENGTH = 255
+        const val REGEX_PATTERN = "^[a-zA-Z0-9_-]+$"
+        private val regex = Regex(REGEX_PATTERN)
+    }
+
+    init {
+        require(value.isNotBlank()) { "Name must not be empty or blank." }
+        require(value.length <= MAX_LENGTH) { "Name must not exceed $MAX_LENGTH characters." }
+        require(value.matches(regex)) { "Name must contain only alphanumeric characters, hyphens, and underscores." }
+    }
+}

--- a/factstore-specification/src/test/kotlin/io/factstore/core/FactStoreNameTest.kt
+++ b/factstore-specification/src/test/kotlin/io/factstore/core/FactStoreNameTest.kt
@@ -1,0 +1,79 @@
+package io.factstore.core
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.Test
+
+class FactStoreNameTest {
+
+    @Test
+    fun `create should reject empty names`(): Unit = runBlocking {
+        listOf(
+            "",
+            " "
+        ).forEach { invalidName ->
+            val exception = catchThrowable {
+                runBlocking { FactStoreName(invalidName) }
+            }
+
+            assertThat(exception)
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("Name must not be empty or blank.")
+        }
+    }
+
+    @Test
+    fun `create should reject names with invalid characters`(): Unit = runBlocking {
+        listOf(
+            "my store", // space
+            "my.store", // dot
+            "my/store", // slash
+            "my@store", // at sign
+            "my:store", // colon
+            "my\$store", // dollar
+            "Mÿ_store", // non-ASCII
+        ).forEach { invalidName ->
+            val exception = catchThrowable {
+                runBlocking { FactStoreName(invalidName) }
+            }
+
+            assertThat(exception)
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun `create should accept alphanumeric and hyphen and underscore`(): Unit = runBlocking {
+        val validNames = listOf(
+            "my-store",
+            "my_store",
+            "MyStore123",
+            "store-123",
+            "store_456",
+            "store123",
+            "a",
+            "A",
+            "0",
+            "abc123_-def",
+        )
+
+        validNames.forEach { validName ->
+            assertThat(FactStoreName(validName)).matches { it.value == validName }
+
+        }
+    }
+
+    @Test
+    fun `create should reject names exceeding 255 characters`(): Unit = runBlocking {
+        val longName = "a".repeat(256)
+
+        val exception = catchThrowable {
+            runBlocking { FactStoreName(longName) }
+        }
+
+        assertThat(exception)
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("255")
+    }
+}


### PR DESCRIPTION
This development adds an initial factstore management API where clients can create and retrieve logical fact stores. 

Later, checks about the existence of fact stores must be taken into account (e.g., when appending events).