### PR TITLE
#135 use store name in APIs instead of ID and resolve ID internally

### DIFF
--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactAppender.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactAppender.kt
@@ -16,13 +16,13 @@ class FdbFactAppender(
     private val store: FdbFactStore,
 ) : FactAppender {
 
-    override suspend fun append(storeId: StoreId, fact: Fact): AppendResult =
-        append(storeId, listOf(fact))
+    override suspend fun append(storeName: StoreName, fact: Fact): AppendResult =
+        append(storeName, listOf(fact))
 
-    override suspend fun append(storeId: StoreId, facts: List<Fact>): AppendResult =
+    override suspend fun append(storeName: StoreName, facts: List<Fact>): AppendResult =
         append(
             AppendRequest(
-                storeId = storeId,
+                storeName = storeName,
                 facts = facts,
                 idempotencyKey = IdempotencyKey(),
                 condition = AppendCondition.None
@@ -30,31 +30,33 @@ class FdbFactAppender(
         )
 
     override suspend fun append(request: AppendRequest): AppendResult =
-        store.db.runAsync { tr ->
-
+        store.db.runAsync { tr -> with(tr) {
             // check fact store exists
-            store.context.getMetadata(request.storeId, tr).thenCompose { metadata ->
-                if (metadata == null) {
+            store.context.lookUpStoreIdByName(request.storeName).thenCompose { storeId ->
+                if (storeId == null) {
                     return@thenCompose CompletableFuture.completedFuture(AppendResult.StoreNotFound)
                 } else {
-                    val idempotencyKey = request.idempotencyKeyBytes()
+                    with(storeId) {
+                        val idempotencyKey = request.idempotencyKeyBytes()
 
-                    tr[idempotencyKey].thenCompose { existing ->
-                        if (existing != null) {
-                            CompletableFuture.completedFuture(AppendResult.AlreadyApplied)
-                        } else {
-                            with(tr) {
-                                request.validate().thenCompose {
-                                    request.appendNew()
+                        tr[idempotencyKey].thenCompose { existing ->
+                            if (existing != null) {
+                                CompletableFuture.completedFuture(AppendResult.AlreadyApplied)
+                            } else {
+                                with(storeId) {
+                                    request.validate().thenCompose {
+                                        request.appendNew()
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
+        }
         }.await()
 
-    context(transaction: Transaction)
+    context(transaction: Transaction, storeId: StoreId)
     private fun AppendRequest.validate(): CompletableFuture<Unit> {
         val checks: List<CompletableFuture<FactId?>> = facts.map { fact ->
             store.context.factPositionIndexSubspace.exists(storeId, fact.id).thenApply { exists ->
@@ -72,7 +74,7 @@ class FdbFactAppender(
             }
     }
 
-    context(tr: Transaction)
+    context(tr: Transaction, storeId: StoreId)
     private fun AppendRequest.appendNew(): CompletableFuture<AppendResult> {
 
         return this.condition.isSatisfied().thenApply { satisfied ->
@@ -86,7 +88,7 @@ class FdbFactAppender(
         }
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun AppendCondition.isSatisfied(): CompletableFuture<Boolean> =
         when (this) {
             AppendCondition.None -> CompletableFuture.completedFuture(true)
@@ -95,49 +97,50 @@ class FdbFactAppender(
             is AppendCondition.ExpectedMultiSubjectLastFact -> isSatisfied()
         }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun AppendCondition.ExpectedLastFact.isSatisfied(): CompletableFuture<Boolean> {
         val actualLastFactId = subjectRef.getLastFactId()
         val isConditionSatisfied = actualLastFactId == expectedLastFactId
         return CompletableFuture.completedFuture(isConditionSatisfied)
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun AppendCondition.ExpectedMultiSubjectLastFact.isSatisfied(): CompletableFuture<Boolean> {
         val isSatisfied = expectations.all { it.key.getLastFactId() == it.value }
         return CompletableFuture.completedFuture(isSatisfied)
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun SubjectRef.getLastFactId(): FactId? {
-        val subjectRange = store.context.subjectIndexSubspace.range(appendRequest.storeId, this)
+        val subjectRange = store.context.subjectIndexSubspace.range(storeId, this)
         val latestFactKeyValue = tr.getRange(subjectRange, LIMIT_ONE, REVERSED).firstOrNull()
         return latestFactKeyValue?.let {
             Tuple.fromBytes(it.value).getFirstAsFactId()
         }
     }
 
+    context(storeId: StoreId)
     private fun AppendRequest.idempotencyKeyBytes(): ByteArray =
         store.context.idempotencySubspace.pack(storeId, idempotencyKey)
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, appendRequest: AppendRequest, storeId: StoreId)
     private fun List<Fact>.store() = with(store) {
-        appendRequest.storeId.apply { this@store.store() }
+        appendRequest.storeName.apply { this@store.store() }
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun AppendCondition.TagQueryBased.isSatisfied(): CompletableFuture<Boolean> {
         return after?.getPosition()?.thenCompose { position ->
             queryItemsForPosition(position)
         } ?: queryItemsForPosition()
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun FactId.getPosition() = with(store) {
-        context.factPositionIndexSubspace.getPosition(appendRequest.storeId, this@getPosition)
+        context.factPositionIndexSubspace.getPosition(storeId, this@getPosition)
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun AppendCondition.TagQueryBased.queryItemsForPosition(
         afterPosition: FactPosition? = null
     ): CompletableFuture<Boolean> {
@@ -154,7 +157,7 @@ class FdbFactAppender(
         }
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun TagQueryItem.resolveFactIds(
         afterPosition: FactPosition? = null
     ): CompletableFuture<Set<FactId>> = when (this) {
@@ -162,7 +165,7 @@ class FdbFactAppender(
         is TagTypeItem -> queryByTypeAndTags(afterPosition)
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun TagOnlyQueryItem.queryByTags(
         afterPosition: FactPosition?
     ): CompletableFuture<Set<FactId>> {
@@ -174,10 +177,10 @@ class FdbFactAppender(
         ): Pair<KeySelector, KeySelector> {
             val key = if (afterPosition != null) {
                 // If there's a afterPosition, include it in the tuple
-                store.context.tagsIndexSubspace.getKey(appendRequest.storeId, tag, afterPosition)
+                store.context.tagsIndexSubspace.getKey(storeId, tag, afterPosition)
             } else {
                 // If there's no afterPosition, just use the tag
-                store.context.tagsIndexSubspace.getKey(appendRequest.storeId, tag)
+                store.context.tagsIndexSubspace.getKey(storeId, tag)
             }
 
             // Create the beginSelector (first greater than if afterPosition is provided)
@@ -188,7 +191,7 @@ class FdbFactAppender(
             }
 
             // Create the end selector based on the tag range
-            val range = store.context.tagsIndexSubspace.range(appendRequest.storeId, tag)
+            val range = store.context.tagsIndexSubspace.range(storeId, tag)
             val endSelector = KeySelector.lastLessOrEqual(range.end)
 
             return Pair(beginSelector, endSelector)
@@ -216,7 +219,7 @@ class FdbFactAppender(
         }
     }
 
-    context(tr: Transaction, appendRequest: AppendRequest)
+    context(tr: Transaction, storeId: StoreId)
     private fun TagTypeItem.queryByTypeAndTags(
         afterPosition: FactPosition?
     ): CompletableFuture<Set<FactId>> {
@@ -227,9 +230,9 @@ class FdbFactAppender(
             afterPosition: FactPosition?
         ): Pair<KeySelector, KeySelector> {
             val key = if (afterPosition != null) {
-                store.context.tagsTypeIndexSubspace.getKey(appendRequest.storeId, type, tag, afterPosition)
+                store.context.tagsTypeIndexSubspace.getKey(storeId, type, tag, afterPosition)
             } else {
-                store.context.tagsTypeIndexSubspace.getKey(appendRequest.storeId, type, tag)
+                store.context.tagsTypeIndexSubspace.getKey(storeId, type, tag)
             }
 
             val startKeySelector = if (afterPosition != null) {
@@ -238,7 +241,7 @@ class FdbFactAppender(
                 KeySelector(key, OR_EQUAL, ZERO_OFFSET)
             }
 
-            val range = store.context.tagsTypeIndexSubspace.range(appendRequest.storeId, type, tag)
+            val range = store.context.tagsTypeIndexSubspace.range(storeId, type, tag)
             val endSelector = KeySelector.lastLessOrEqual(range.end)
 
             return Pair(startKeySelector, endSelector)

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactAppender.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactAppender.kt
@@ -30,22 +30,24 @@ class FdbFactAppender(
         )
 
     override suspend fun append(request: AppendRequest): AppendResult =
-        store.db.runAsync { tr -> with(tr) {
-            // check fact store exists
-            store.context.lookUpStoreIdByName(request.storeName).thenCompose { storeId ->
-                if (storeId == null) {
-                    return@thenCompose CompletableFuture.completedFuture(AppendResult.StoreNotFound)
-                } else {
-                    with(storeId) {
-                        val idempotencyKey = request.idempotencyKeyBytes()
+        store.db.runAsync { tr ->
+            with(tr) {
+                // check fact store exists
+                store.context.lookUpStoreIdByName(request.storeName).thenCompose { storeId ->
+                    if (storeId == null) {
+                        return@thenCompose CompletableFuture.completedFuture(AppendResult.StoreNotFound)
+                    } else {
+                        with(storeId) {
+                            val idempotencyKey = request.idempotencyKeyBytes()
 
-                        tr[idempotencyKey].thenCompose { existing ->
-                            if (existing != null) {
-                                CompletableFuture.completedFuture(AppendResult.AlreadyApplied)
-                            } else {
-                                with(storeId) {
-                                    request.validate().thenCompose {
-                                        request.appendNew()
+                            tr[idempotencyKey].thenCompose { existing ->
+                                if (existing != null) {
+                                    CompletableFuture.completedFuture(AppendResult.AlreadyApplied)
+                                } else {
+                                    with(storeId) {
+                                        request.validate().thenCompose {
+                                            request.appendNew()
+                                        }
                                     }
                                 }
                             }
@@ -53,7 +55,6 @@ class FdbFactAppender(
                     }
                 }
             }
-        }
         }.await()
 
     context(transaction: Transaction, storeId: StoreId)

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactFinder.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactFinder.kt
@@ -16,15 +16,19 @@ class FdbFactFinder(private val fdbFactStore: FdbFactStore) : FactFinder {
     private val tagsIndexSubspace = fdbFactStore.context.tagsIndexSubspace
     private val tagsTypeIndexSubspace = fdbFactStore.context.tagsTypeIndexSubspace
 
-    override suspend fun findById(storeId: StoreId, factId: FactId): FindByIdResult =
+    override suspend fun findById(storeName: StoreName, factId: FactId): FindByIdResult =
         db.readAsync { tr ->
             with(tr) {
-                factId.loadFact(storeId).thenCompose { fact ->
-                    if (fact != null) {
-                        CompletableFuture.completedFuture(FindByIdResult.Found(fact))
+                fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                    if (storeId == null) {
+                        CompletableFuture.completedFuture(FindByIdResult.StoreNotFound)
                     } else {
-                        fdbFactStore.context.getMetadata(storeId, tr).thenApply { metadata ->
-                            if (metadata == null) FindByIdResult.StoreNotFound else FindByIdResult.NotFound(factId)
+                        factId.loadFact(storeId).thenApply { fact ->
+                            if (fact != null) {
+                                FindByIdResult.Found(fact)
+                            } else {
+                                FindByIdResult.NotFound(factId)
+                            }
                         }
                     }
                 }
@@ -32,28 +36,32 @@ class FdbFactFinder(private val fdbFactStore: FdbFactStore) : FactFinder {
         }.await()
 
 
-    override suspend fun existsById(storeId: StoreId, factId: FactId): ExistsByIdResult =
+    override suspend fun existsById(storeName: StoreName, factId: FactId): ExistsByIdResult =
         db.readAsync { tr ->
             with(tr) {
-                factId.existsById(storeId).thenCompose { exists ->
-                    if (exists) {
-                        CompletableFuture.completedFuture(ExistsByIdResult.Exists)
+                fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                    if (storeId == null) {
+                        CompletableFuture.completedFuture(ExistsByIdResult.StoreNotFound)
                     } else {
-                        fdbFactStore.context.getMetadata(storeId, tr).thenApply { metadata ->
-                            if (metadata == null) ExistsByIdResult.StoreNotFound else ExistsByIdResult.DoesNotExist
+                        factId.existsById(storeId).thenApply { exists ->
+                            if (exists) {
+                                ExistsByIdResult.Exists
+                            } else {
+                                ExistsByIdResult.DoesNotExist
+                            }
                         }
                     }
                 }
             }
         }.await()
 
-    override suspend fun findInTimeRange(storeId: StoreId, timeRange: TimeRange): FindInTimeRangeResult {
+    override suspend fun findInTimeRange(storeName: StoreName, timeRange: TimeRange): FindInTimeRangeResult {
         val start = timeRange.start
         val end = timeRange.end
 
-        return db.readAsync { tr ->
-            fdbFactStore.context.getMetadata(storeId, tr).thenCompose { metadata ->
-                if (metadata == null) {
+        return db.readAsync { tr -> with(tr) {
+            fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                if (storeId == null) {
                     CompletableFuture.completedFuture(FindInTimeRangeResult.StoreNotFound)
                 } else {
                     val begin = createdAtIndexSubspace.getKey(storeId, start)
@@ -73,13 +81,14 @@ class FdbFactFinder(private val fdbFactStore: FdbFactStore) : FactFinder {
                     }
                 }
             }
+        }
         }.await()
     }
 
-    override suspend fun findBySubject(storeId: StoreId, subjectRef: SubjectRef): FindBySubjectResult {
-        return db.readAsync { tr ->
-            fdbFactStore.context.getMetadata(storeId, tr).thenCompose { metadata ->
-                if (metadata == null) {
+    override suspend fun findBySubject(storeName: StoreName, subjectRef: SubjectRef): FindBySubjectResult {
+        return db.readAsync { tr -> with(tr) {
+            fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                if (storeId == null) {
                     CompletableFuture.completedFuture(FindBySubjectResult.StoreNotFound)
                 } else {
                     val subjectRange = subjectIndexSubspace.range(storeId, subjectRef)
@@ -96,13 +105,14 @@ class FdbFactFinder(private val fdbFactStore: FdbFactStore) : FactFinder {
                     }
                 }
             }
+        }
         }.await()
     }
 
-    override suspend fun findByTags(storeId: StoreId, tags: List<Pair<TagKey, TagValue>>): FindByTagsResult {
-        return db.readAsync { tr ->
-            fdbFactStore.context.getMetadata(storeId, tr).thenCompose { metadata ->
-                if (metadata == null) {
+    override suspend fun findByTags(storeName: StoreName, tags: List<Pair<TagKey, TagValue>>): FindByTagsResult {
+        return db.readAsync { tr -> with(tr) {
+            fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                if (storeId == null) {
                     CompletableFuture.completedFuture(FindByTagsResult.StoreNotFound)
                 } else {
                     if (tags.isEmpty()) return@thenCompose CompletableFuture.completedFuture(FindByTagsResult.Found(emptyList()))
@@ -138,13 +148,15 @@ class FdbFactFinder(private val fdbFactStore: FdbFactStore) : FactFinder {
                     }
                 }
             }
+        }
+
         }.await()
     }
 
-    override suspend fun findByTagQuery(storeId: StoreId, query: TagQuery): FindByTagQueryResult {
-        return db.readAsync { tr ->
-            fdbFactStore.context.getMetadata(storeId, tr).thenCompose { metadata ->
-                if (metadata == null) {
+    override suspend fun findByTagQuery(storeName: StoreName, query: TagQuery): FindByTagQueryResult {
+        return db.readAsync { tr -> with(tr) {
+            fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                if (storeId == null) {
                     CompletableFuture.completedFuture(FindByTagQueryResult.StoreNotFound)
                 } else {
                     with(tr.snapshot()) {
@@ -173,6 +185,8 @@ class FdbFactFinder(private val fdbFactStore: FdbFactStore) : FactFinder {
                     }
                 }
             }
+        }
+
         }.await()
     }
 

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactFinder.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactFinder.kt
@@ -59,134 +59,141 @@ class FdbFactFinder(private val fdbFactStore: FdbFactStore) : FactFinder {
         val start = timeRange.start
         val end = timeRange.end
 
-        return db.readAsync { tr -> with(tr) {
-            fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
-                if (storeId == null) {
-                    CompletableFuture.completedFuture(FindInTimeRangeResult.StoreNotFound)
-                } else {
-                    val begin = createdAtIndexSubspace.getKey(storeId, start)
-                    val endKey = createdAtIndexSubspace.getKey(storeId, end)
+        return db.readAsync { tr ->
+            with(tr) {
+                fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                    if (storeId == null) {
+                        CompletableFuture.completedFuture(FindInTimeRangeResult.StoreNotFound)
+                    } else {
+                        val begin = createdAtIndexSubspace.getKey(storeId, start)
+                        val endKey = createdAtIndexSubspace.getKey(storeId, end)
 
-                    tr.getRange(begin, endKey).asList().thenCompose { kvs ->
-                        val factFutures: List<CompletableFuture<FdbFact?>> = kvs.map { kv ->
-                            val factPosition = createdAtIndexSubspace.unpackPosition(kv.key)
-                            tr.run { factPosition.lookupFact(storeId) }
-                        }
+                        tr.getRange(begin, endKey).asList().thenCompose { kvs ->
+                            val factFutures: List<CompletableFuture<FdbFact?>> = kvs.map { kv ->
+                                val factPosition = createdAtIndexSubspace.unpackPosition(kv.key)
+                                tr.run { factPosition.lookupFact(storeId) }
+                            }
 
-                        // wait for all facts to complete
-                        CompletableFuture.allOf(*factFutures.toTypedArray()).thenApply {
-                            val facts = factFutures.mapNotNull { it.resultNow()?.fact }
-                            FindInTimeRangeResult.Found(facts)
+                            // wait for all facts to complete
+                            CompletableFuture.allOf(*factFutures.toTypedArray()).thenApply {
+                                val facts = factFutures.mapNotNull { it.resultNow()?.fact }
+                                FindInTimeRangeResult.Found(facts)
+                            }
                         }
                     }
                 }
             }
-        }
         }.await()
     }
 
     override suspend fun findBySubject(storeName: StoreName, subjectRef: SubjectRef): FindBySubjectResult {
-        return db.readAsync { tr -> with(tr) {
-            fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
-                if (storeId == null) {
-                    CompletableFuture.completedFuture(FindBySubjectResult.StoreNotFound)
-                } else {
-                    val subjectRange = subjectIndexSubspace.range(storeId, subjectRef)
-                    tr.getRange(subjectRange).asList().thenCompose { kvs ->
-                        val factFutures: List<CompletableFuture<FdbFact?>> = kvs.map { kv ->
-                            val factPosition = subjectIndexSubspace.unpackPosition(kv.key)
-                            tr.run { factPosition.lookupFact(storeId) }
-                        }
+        return db.readAsync { tr ->
+            with(tr) {
+                fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                    if (storeId == null) {
+                        CompletableFuture.completedFuture(FindBySubjectResult.StoreNotFound)
+                    } else {
+                        val subjectRange = subjectIndexSubspace.range(storeId, subjectRef)
+                        tr.getRange(subjectRange).asList().thenCompose { kvs ->
+                            val factFutures: List<CompletableFuture<FdbFact?>> = kvs.map { kv ->
+                                val factPosition = subjectIndexSubspace.unpackPosition(kv.key)
+                                tr.run { factPosition.lookupFact(storeId) }
+                            }
 
-                        CompletableFuture.allOf(*factFutures.toTypedArray()).thenApply {
-                            val facts = factFutures.mapNotNull { it.resultNow()?.fact }
-                            FindBySubjectResult.Found(facts)
+                            CompletableFuture.allOf(*factFutures.toTypedArray()).thenApply {
+                                val facts = factFutures.mapNotNull { it.resultNow()?.fact }
+                                FindBySubjectResult.Found(facts)
+                            }
                         }
                     }
                 }
             }
-        }
         }.await()
     }
 
     override suspend fun findByTags(storeName: StoreName, tags: List<Pair<TagKey, TagValue>>): FindByTagsResult {
-        return db.readAsync { tr -> with(tr) {
-            fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
-                if (storeId == null) {
-                    CompletableFuture.completedFuture(FindByTagsResult.StoreNotFound)
-                } else {
-                    if (tags.isEmpty()) return@thenCompose CompletableFuture.completedFuture(FindByTagsResult.Found(emptyList()))
+        return db.readAsync { tr ->
+            with(tr) {
+                fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                    if (storeId == null) {
+                        CompletableFuture.completedFuture(FindByTagsResult.StoreNotFound)
+                    } else {
+                        if (tags.isEmpty()) return@thenCompose CompletableFuture.completedFuture(
+                            FindByTagsResult.Found(
+                                emptyList()
+                            )
+                        )
 
-                    // For each (key, value) pair, get matching factIds
-                    val tagFutures: List<CompletableFuture<Set<FactPosition>>> = tags.map { (key, value) ->
-                        val range = tagsIndexSubspace.range(storeId, key, value)
-                        tr.getRange(range).asList().thenApply { kvs ->
-                            kvs.mapTo(mutableSetOf()) { kv ->
-                                tagsIndexSubspace.unpackPosition(kv.key)
+                        // For each (key, value) pair, get matching factIds
+                        val tagFutures: List<CompletableFuture<Set<FactPosition>>> = tags.map { (key, value) ->
+                            val range = tagsIndexSubspace.range(storeId, key, value)
+                            tr.getRange(range).asList().thenApply { kvs ->
+                                kvs.mapTo(mutableSetOf()) { kv ->
+                                    tagsIndexSubspace.unpackPosition(kv.key)
+                                }
                             }
                         }
-                    }
 
-                    // Once all tag lookups finish, union them and load facts
-                    CompletableFuture.allOf(*tagFutures.toTypedArray()).thenCompose {
-                        val allFactPositions: Set<FactPosition> = tagFutures
-                            .flatMap { it.getNow(emptySet()) }
-                            .toSet() // OR semantics = union
+                        // Once all tag lookups finish, union them and load facts
+                        CompletableFuture.allOf(*tagFutures.toTypedArray()).thenCompose {
+                            val allFactPositions: Set<FactPosition> = tagFutures
+                                .flatMap { it.getNow(emptySet()) }
+                                .toSet() // OR semantics = union
 
-                        with(tr) {
-                            val loadFutures: List<CompletableFuture<FdbFact?>> =
-                                allFactPositions.map { it.lookupFact(storeId) }
+                            with(tr) {
+                                val loadFutures: List<CompletableFuture<FdbFact?>> =
+                                    allFactPositions.map { it.lookupFact(storeId) }
 
-                            CompletableFuture.allOf(*loadFutures.toTypedArray()).thenApply {
-                                val facts = loadFutures
-                                    .mapNotNull { it.resultNow() }
-                                    .sortedBy { it.factPosition }
-                                    .map { it.fact }
-                                FindByTagsResult.Found(facts)
+                                CompletableFuture.allOf(*loadFutures.toTypedArray()).thenApply {
+                                    val facts = loadFutures
+                                        .mapNotNull { it.resultNow() }
+                                        .sortedBy { it.factPosition }
+                                        .map { it.fact }
+                                    FindByTagsResult.Found(facts)
+                                }
                             }
                         }
                     }
                 }
             }
-        }
 
         }.await()
     }
 
     override suspend fun findByTagQuery(storeName: StoreName, query: TagQuery): FindByTagQueryResult {
-        return db.readAsync { tr -> with(tr) {
-            fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
-                if (storeId == null) {
-                    CompletableFuture.completedFuture(FindByTagQueryResult.StoreNotFound)
-                } else {
-                    with(tr.snapshot()) {
-                        val queryItemFutures = query.queryItems
-                            .map { queryItem ->
-                                // map query item to list of fact IDs
-                                storeId.run { queryItem.resolveFactPositions() }
-                            }
+        return db.readAsync { tr ->
+            with(tr) {
+                fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
+                    if (storeId == null) {
+                        CompletableFuture.completedFuture(FindByTagQueryResult.StoreNotFound)
+                    } else {
+                        with(tr.snapshot()) {
+                            val queryItemFutures = query.queryItems
+                                .map { queryItem ->
+                                    // map query item to list of fact IDs
+                                    storeId.run { queryItem.resolveFactPositions() }
+                                }
 
-                        CompletableFuture.allOf(*queryItemFutures.toTypedArray()).thenCompose {
-                            val allFactPositions: Set<FactPosition> = queryItemFutures
-                                .flatMap { it.getNow(emptySet()) }
-                                .toSet() // OR semantics = union
+                            CompletableFuture.allOf(*queryItemFutures.toTypedArray()).thenCompose {
+                                val allFactPositions: Set<FactPosition> = queryItemFutures
+                                    .flatMap { it.getNow(emptySet()) }
+                                    .toSet() // OR semantics = union
 
-                            val loadFutures: List<CompletableFuture<FdbFact?>> =
-                                allFactPositions.map { it.lookupFact(storeId) }
+                                val loadFutures: List<CompletableFuture<FdbFact?>> =
+                                    allFactPositions.map { it.lookupFact(storeId) }
 
-                            CompletableFuture.allOf(*loadFutures.toTypedArray()).thenApply {
-                                val facts = loadFutures
-                                    .mapNotNull { it.getNow(null) }
-                                    .sortedBy { it.factPosition }
-                                    .map { it.fact }
-                                FindByTagQueryResult.Found(facts)
+                                CompletableFuture.allOf(*loadFutures.toTypedArray()).thenApply {
+                                    val facts = loadFutures
+                                        .mapNotNull { it.getNow(null) }
+                                        .sortedBy { it.factPosition }
+                                        .map { it.fact }
+                                    FindByTagQueryResult.Found(facts)
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-
         }.await()
     }
 

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStoreContext.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStoreContext.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture
 
 data class FdbFactStoreContext(
     val storeSubspace: Subspace,
-    val storeNameToIdIndex: Subspace,
+    val storeNameToIdIndex: StoreNameToIdIndexSubspace,
     val factSubspace: FactSubspace,
     val headSubspace: HeadSubspace,
     val factPositionIndexSubspace: FactPositionIndexSubspace,
@@ -43,7 +43,7 @@ data class FdbFactStoreContext(
             val root = rootDirectory.rootDirectorySubspace
             return FdbFactStoreContext(
                 storeSubspace = root.subspace(Tuple.from(STORES)),
-                storeNameToIdIndex = root.subspace(Tuple.from(STORE_INDEX)),
+                storeNameToIdIndex = StoreNameToIdIndexSubspace(root.subspace(Tuple.from(STORE_INDEX))),
                 factSubspace = FactSubspace(root.subspace(Tuple.from(FACTS))),
                 headSubspace = HeadSubspace(root.subspace(Tuple.from(HEAD_INDEX))),
                 factPositionIndexSubspace = FactPositionIndexSubspace(root.subspace(Tuple.from(FACT_POSITIONS))),
@@ -67,13 +67,43 @@ fun FdbFactStoreContext.getMetadata(storeId: StoreId, tr: ReadTransaction): Comp
 
 fun FdbFactStoreContext.saveMetadata(metadata: FdbStoreMetadata, tr: Transaction) {
     tr[storeSubspace.pack(Tuple.from(metadata.storeId))] = Avro.encodeToByteArray(metadata)
-    tr[storeNameToIdIndex.pack(Tuple.from(metadata.name))] = Tuple.from(metadata.storeId).pack()
+    with(tr) {
+        storeNameToIdIndex.save(StoreName(metadata.name), StoreId(metadata.storeId))
+    }
 }
 
 fun FdbFactStoreContext.lookUpFactstoreIdByName(name: StoreName, tr: ReadTransaction): CompletableFuture<StoreId?> =
-    tr[storeNameToIdIndex.pack(Tuple.from(name.value))].thenApply { valueBytes ->
-        valueBytes?.let { StoreId(Tuple.fromBytes(it).getUUID(0)) }
+    with(tr) {
+        storeNameToIdIndex.lookUpStore(name)
     }
+
+context(tr: ReadTransaction)
+fun FdbFactStoreContext.lookUpStoreIdByName(name: StoreName): CompletableFuture<StoreId?> =
+    with(tr) {
+        storeNameToIdIndex.lookUpStore(name)
+    }
+
+@JvmInline
+value class StoreNameToIdIndexSubspace(val subspace: Subspace) {
+
+    context(tr: ReadTransaction)
+    fun lookUpStore(name: StoreName): CompletableFuture<StoreId?> {
+        return tr[subspace.pack(Tuple.from(name.value))].thenApply { valueBytes ->
+            valueBytes?.let { StoreId(Tuple.fromBytes(it).getUUID(0)) }
+        }
+    }
+
+    context(tr: ReadTransaction)
+    fun exists(name: StoreName): CompletableFuture<Boolean> {
+        return tr[subspace.pack(Tuple.from(name.value))].thenApply { it != null }
+    }
+
+    context(tr: Transaction)
+    fun save(name: StoreName, storeId: StoreId) {
+        tr[subspace.pack(Tuple.from(name.value))] = Tuple.from(storeId.uuid).pack()
+    }
+
+}
 
 @JvmInline
 value class HeadSubspace(val subspace: Subspace) {

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStreamer.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStreamer.kt
@@ -19,17 +19,18 @@ class FdbFactStreamer(
 ) : FactStreamer {
 
     override suspend fun stream(
-        storeId: StoreId,
+        storeName: StoreName,
         streamingOptions: StreamingOptions
     ): StreamResult {
 
         // Check existence
-        val storeExists = read { tr ->
-            store.context.getMetadata(storeId, tr)
-                .thenApply { it != null }
+        val storeId = read { tr ->
+            with(tr) {
+                store.context.lookUpStoreIdByName(storeName)
+            }
         }
 
-        if (!storeExists) {
+        if (storeId == null) {
             return StoreNotFound
         }
 
@@ -90,8 +91,10 @@ class FdbFactStreamer(
 
     sealed interface CursorResult {
         data object Beginning : CursorResult
+
         @JvmInline
         value class Found(val key: ByteArray) : CursorResult
+
         @JvmInline
         value class FactNotFound(val factId: FactId) : CursorResult
     }
@@ -107,6 +110,7 @@ class FdbFactStreamer(
                 if (key == null) CursorResult.Beginning
                 else CursorResult.Found(key)
             }
+
             is StartPosition.After -> {
                 val key = getKeyForFactOrNull(startPosition.factId)
                 if (key == null) CursorResult.FactNotFound(startPosition.factId)

--- a/factstore-memory/src/main/kotlin/io/factstore/memory/MemoryFactStore.kt
+++ b/factstore-memory/src/main/kotlin/io/factstore/memory/MemoryFactStore.kt
@@ -11,35 +11,33 @@ import java.util.*
 /**
  * In-memory implementation of FactStore for testing and evaluation purposes.
  *
- * This implementation stores all facts and metadata in memory without any persistence.
- * It is not suitable for production use but provides a simple, fast alternative for
- * testing and prototyping.
- *
+ * This implementation abstracts logical [StoreName]s from internal [UUID] identifiers.
  * Thread-safety is ensured through the use of coroutine mutexes.
- *
- * @author Domenic Cassisi
  */
 class MemoryFactStore : FactStore {
 
-    // Store metadata: StoreId -> StoreMetadata
+    // Store metadata: Internal ID -> StoreMetadata
     private val stores = mutableMapOf<UUID, StoreMetadata>()
 
-    // Store name -> StoreId index
-    private val nameIndex = mutableMapOf<String, UUID>()
+    // Logical Name -> Internal ID (The "Name Resolver")
+    private val nameToId = mutableMapOf<String, UUID>()
 
-    // Store facts: StoreId -> list of facts
+    // Store facts: Internal ID -> list of facts
     private val facts = mutableMapOf<UUID, MutableList<Fact>>()
 
-    // Store idempotency tracking: StoreId -> (IdempotencyKey -> exists flag)
+    // Store idempotency tracking: Internal ID -> (IdempotencyKey -> exists flag)
     private val idempotencyKeys = mutableMapOf<UUID, MutableSet<UUID>>()
 
     private val lock = Mutex()
 
+    // ===== Helper: Name Resolution =====
+
+    private fun resolveId(name: StoreName): UUID? = nameToId[name.value]
+
     // ===== FactStoreFactory Implementation =====
 
     override suspend fun handle(request: CreateStoreRequest): CreateStoreResult = lock.withLock {
-        val existingId = nameIndex[request.storeName.value]
-        if (existingId != null) {
+        if (nameToId.containsKey(request.storeName.value)) {
             return CreateStoreResult.NameAlreadyExists(request.storeName)
         }
 
@@ -51,7 +49,7 @@ class MemoryFactStore : FactStore {
         )
 
         stores[id.uuid] = metadata
-        nameIndex[request.storeName.value] = id.uuid
+        nameToId[request.storeName.value] = id.uuid
         facts[id.uuid] = mutableListOf()
         idempotencyKeys[id.uuid] = mutableSetOf()
 
@@ -65,43 +63,39 @@ class MemoryFactStore : FactStore {
     }
 
     override suspend fun existsByName(name: StoreName): Boolean = lock.withLock {
-        nameIndex.containsKey(name.value)
+        nameToId.containsKey(name.value)
     }
 
     override suspend fun findByName(name: StoreName): StoreMetadata? = lock.withLock {
-        nameIndex[name.value]?.let { id ->
-            stores[id]
-        }
+        resolveId(name)?.let { stores[it] }
     }
 
-    // ===== FactAppender Implementation =====
+    override suspend fun append(storeName: StoreName, fact: Fact): AppendResult =
+        append(storeName, listOf(fact))
 
-    override suspend fun append(storeId: StoreId, fact: Fact): AppendResult =
-        append(storeId, listOf(fact))
-
-    override suspend fun append(storeId: StoreId, facts: List<Fact>): AppendResult =
+    override suspend fun append(storeName: StoreName, facts: List<Fact>): AppendResult =
         append(
             AppendRequest(
-                storeId = storeId,
+                storeName = storeName,
                 facts = facts,
                 idempotencyKey = IdempotencyKey(),
                 condition = AppendCondition.None
             )
         )
 
+    // ===== FactAppender Implementation =====
+
     override suspend fun append(request: AppendRequest): AppendResult = lock.withLock {
-        // Check if fact store exists
-        val storeMetadata = stores[request.storeId.uuid]
-            ?: return AppendResult.StoreNotFound
+        val storeId = resolveId(request.storeName) ?: return AppendResult.StoreNotFound
 
         // Check idempotency
-        val idempotencySet = idempotencyKeys[request.storeId.uuid]!!
+        val idempotencySet = idempotencyKeys[storeId]!!
         if (idempotencySet.contains(request.idempotencyKey.value)) {
             return AppendResult.AlreadyApplied
         }
 
         // Check for duplicate fact IDs
-        val store = facts[request.storeId.uuid]!!
+        val store = facts[storeId]!!
         val existingIds = store.map { it.id.uuid }.toSet()
         val duplicates = request.facts.filter { it.id.uuid in existingIds }
         if (duplicates.isNotEmpty()) {
@@ -109,15 +103,12 @@ class MemoryFactStore : FactStore {
         }
 
         // Check append condition
-        val conditionSatisfied = checkAppendCondition(request.storeId.uuid, request.condition)
-        if (!conditionSatisfied) {
+        if (!checkAppendCondition(storeId, request.condition)) {
             return AppendResult.AppendConditionViolated
         }
 
         // Append facts
-        store.addAll(request.facts)
-
-        // Mark idempotency key as used
+        facts[storeId]!!.addAll(request.facts)
         idempotencySet.add(request.idempotencyKey.value)
 
         AppendResult.Appended
@@ -125,143 +116,88 @@ class MemoryFactStore : FactStore {
 
     // ===== FactFinder Implementation =====
 
-    override suspend fun findById(storeId: StoreId, factId: FactId): FindByIdResult = lock.withLock {
-        if (!stores.containsKey(storeId.uuid)) {
-            FindByIdResult.StoreNotFound
-        } else {
-            val fact = facts[storeId.uuid]?.find { it.id == factId }
-            fact?.let { FindByIdResult.Found(it) } ?: FindByIdResult.NotFound(factId)
-        }
+    override suspend fun findById(storeName: StoreName, factId: FactId): FindByIdResult = lock.withLock {
+        val internalId = resolveId(storeName) ?: return FindByIdResult.StoreNotFound
+
+        val fact = facts[internalId]?.find { it.id == factId }
+        fact?.let { FindByIdResult.Found(it) } ?: FindByIdResult.NotFound(factId)
     }
 
-    override suspend fun existsById(storeId: StoreId, factId: FactId): ExistsByIdResult = lock.withLock {
-        if (!stores.containsKey(storeId.uuid)) {
-            ExistsByIdResult.StoreNotFound
-        } else {
-            val exists = facts[storeId.uuid]?.any { it.id == factId } ?: false
-            if (exists) ExistsByIdResult.Exists else ExistsByIdResult.DoesNotExist
-        }
+    override suspend fun existsById(storeName: StoreName, factId: FactId): ExistsByIdResult = lock.withLock {
+        val internalId = resolveId(storeName) ?: return ExistsByIdResult.StoreNotFound
+
+        val exists = facts[internalId]?.any { it.id == factId } ?: false
+        if (exists) ExistsByIdResult.Exists else ExistsByIdResult.DoesNotExist
     }
 
-    override suspend fun findInTimeRange(storeId: StoreId, timeRange: TimeRange): FindInTimeRangeResult = lock.withLock {
-        if (!stores.containsKey(storeId.uuid)) {
-            FindInTimeRangeResult.StoreNotFound
-        } else {
-            val start = timeRange.start
-            val end = timeRange.end
-            val foundFacts = facts[storeId.uuid]
-                ?.filter { fact -> fact.appendedAt in start..end }
-                ?: emptyList()
-            FindInTimeRangeResult.Found(foundFacts)
-        }
+    override suspend fun findInTimeRange(storeName: StoreName, timeRange: TimeRange): FindInTimeRangeResult = lock.withLock {
+        val internalId = resolveId(storeName) ?: return FindInTimeRangeResult.StoreNotFound
+
+        val foundFacts = facts[internalId]?.filter { it.appendedAt in timeRange.start..timeRange.end } ?: emptyList()
+        FindInTimeRangeResult.Found(foundFacts)
     }
 
-    override suspend fun findBySubject(storeId: StoreId, subjectRef: SubjectRef): FindBySubjectResult = lock.withLock {
-        if (!stores.containsKey(storeId.uuid)) {
-            FindBySubjectResult.StoreNotFound
-        } else {
-            val foundFacts = facts[storeId.uuid]
-                ?.filter { fact -> fact.subjectRef == subjectRef }
-                ?: emptyList()
-            FindBySubjectResult.Found(foundFacts)
-        }
+    override suspend fun findBySubject(storeName: StoreName, subjectRef: SubjectRef): FindBySubjectResult = lock.withLock {
+        val internalId = resolveId(storeName) ?: return FindBySubjectResult.StoreNotFound
+
+        val foundFacts = facts[internalId]?.filter { it.subjectRef == subjectRef } ?: emptyList()
+        FindBySubjectResult.Found(foundFacts)
     }
 
-    override suspend fun findByTags(storeId: StoreId, tags: List<Pair<TagKey, TagValue>>): FindByTagsResult = lock.withLock {
-        if (!stores.containsKey(storeId.uuid)) {
-            FindByTagsResult.StoreNotFound
-        } else {
-            if (tags.isEmpty()) return FindByTagsResult.Found(emptyList())
+    override suspend fun findByTags(storeName: StoreName, tags: List<Pair<TagKey, TagValue>>): FindByTagsResult = lock.withLock {
+        val internalId = resolveId(storeName) ?: return FindByTagsResult.StoreNotFound
 
-            val foundFacts = facts[storeId.uuid]?.filter { fact ->
-                // OR semantics: fact matches if it has any of the specified tag pairs
-                tags.any { (key, value) ->
-                    fact.tags[key] == value
-                }
-            } ?: emptyList()
-            FindByTagsResult.Found(foundFacts)
-        }
+        val foundFacts = facts[internalId]?.filter { fact ->
+            tags.any { (key, value) -> fact.tags[key] == value }
+        } ?: emptyList()
+        FindByTagsResult.Found(foundFacts)
     }
 
-    override suspend fun findByTagQuery(storeId: StoreId, query: TagQuery): FindByTagQueryResult = lock.withLock {
-        if (!stores.containsKey(storeId.uuid)) {
-            FindByTagQueryResult.StoreNotFound
-        } else {
-            val foundFacts = facts[storeId.uuid]?.filter { fact ->
-                // OR semantics: fact matches if it matches any query item
-                query.queryItems.any { queryItem ->
-                    when (queryItem) {
-                        is TagTypeItem -> {
-                            // Type must match AND all tags must match
-                            fact.type in queryItem.types &&
-                                    queryItem.tags.all { (key, value) ->
-                                        fact.tags[key] == value
-                                    }
-                        }
-                        is TagOnlyQueryItem -> {
-                            // All tags must match
-                            queryItem.tags.all { (key, value) ->
-                                fact.tags[key] == value
-                            }
-                        }
-                    }
-                }
-            } ?: emptyList()
-            FindByTagQueryResult.Found(foundFacts)
-        }
+    override suspend fun findByTagQuery(storeName: StoreName, query: TagQuery): FindByTagQueryResult = lock.withLock {
+        val internalId = resolveId(storeName) ?: return FindByTagQueryResult.StoreNotFound
+
+        val foundFacts = facts[internalId]?.filter { fact ->
+            query.queryItems.any { it.matches(fact) }
+        } ?: emptyList()
+        FindByTagQueryResult.Found(foundFacts)
     }
 
     // ===== FactStreamer Implementation =====
 
-    override suspend fun stream(storeId: StoreId, streamingOptions: StreamingOptions): StreamResult {
-        if (!stores.containsKey(storeId.uuid)) {
-            return StreamResult.StoreNotFound
-        }
+    override suspend fun stream(storeName: StoreName, streamingOptions: StreamingOptions): StreamResult {
+        val internalId = lock.withLock { resolveId(storeName) } ?: return StreamResult.StoreNotFound
 
         val startIndex = when (val position = streamingOptions.startPosition) {
             StartPosition.Beginning -> 0
-            StartPosition.End -> {
-                lock.withLock {
-                    facts[storeId.uuid]?.size ?: 0
-                }
-            }
+            StartPosition.End -> lock.withLock { facts[internalId]?.size ?: 0 }
             is StartPosition.After -> {
                 lock.withLock {
-                    val store = facts[storeId.uuid] ?: return StreamResult.StoreNotFound
+                    val store = facts[internalId] ?: return StreamResult.StoreNotFound
                     val index = store.indexOfFirst { it.id == position.factId }
-                    if (index == -1) {
-                        return StreamResult.InvalidStartPosition(position.factId)
-                    }
+                    if (index == -1) return StreamResult.InvalidStartPosition(position.factId)
                     index + 1
                 }
             }
         }
 
-        return StreamResult.FactStream(
-            stream = streamFacts(storeId, startIndex)
-        )
+        return StreamResult.FactStream(streamFacts(internalId, startIndex))
     }
 
-    private fun streamFacts(storeId: StoreId, startIndex: Int) = flow {
+    private fun streamFacts(internalId: UUID, startIndex: Int) = flow {
         var currentIndex = startIndex
         while (true) {
+            var factToEmit: Fact? = null
             lock.withLock {
-                val store = facts[storeId.uuid]
+                val store = facts[internalId]
                 if (store != null && currentIndex < store.size) {
-                    val fact = store[currentIndex]
-                    emit(fact)
+                    factToEmit = store[currentIndex]
                     currentIndex++
                 }
             }
 
-            // If no more facts, wait a bit and try again (simulating watch behavior)
-            if (currentIndex >= (facts[storeId.uuid]?.size ?: 0)) {
-                delay(100)
-            }
+            factToEmit?.let { emit(it) } ?: delay(100)
         }
     }
-
-    // ===== Helper Methods =====
 
     private fun checkAppendCondition(storeId: UUID, condition: AppendCondition): Boolean {
         return when (condition) {
@@ -309,4 +245,12 @@ class MemoryFactStore : FactStore {
             }
         }
     }
+}
+
+/**
+ * Extension for cleaner matching logic in the memory implementation
+ */
+private fun TagQueryItem.matches(fact: Fact): Boolean = when (this) {
+    is TagTypeItem -> fact.type in this.types && this.tags.all { (k, v) -> fact.tags[k] == v }
+    is TagOnlyQueryItem -> this.tags.all { (k, v) -> fact.tags[k] == v }
 }

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/AppendResource.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/AppendResource.kt
@@ -1,6 +1,7 @@
 package io.factstore.server.http
 
 import io.factstore.core.FactStore
+import io.factstore.core.StoreName
 import jakarta.validation.Valid
 import jakarta.ws.rs.*
 import jakarta.ws.rs.core.MediaType.APPLICATION_JSON
@@ -18,8 +19,7 @@ class AppendResource(
         @PathParam("storeName") storeName: String,
         @Valid httpRequest: AppendHttpRequest
     ): Response {
-        val storeId = factStore.resolveStoreOrThrow(storeName).id
-        val appendRequest = httpRequest.toAppendRequest(storeId)
+        val appendRequest = httpRequest.toAppendRequest(StoreName(storeName))
         return factStore.append(appendRequest).toResponse()
     }
 

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/QueryResource.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/QueryResource.kt
@@ -1,11 +1,11 @@
 package io.factstore.server.http
 
-import io.factstore.core.Fact
 import io.factstore.core.FactStore
 import io.factstore.core.FindByIdResult
 import io.factstore.core.FindBySubjectResult
 import io.factstore.core.FindByTagQueryResult
 import io.factstore.core.FindInTimeRangeResult
+import io.factstore.core.StoreName
 import io.factstore.core.SubjectRef
 import io.factstore.core.TimeRange
 import io.factstore.core.toFactId
@@ -30,8 +30,7 @@ class QueryResource(
         @PathParam("factId") factId: UUID,
     ): Response =
         store
-            .resolveStoreOrThrow(storeName)
-            .let { store.findById(it.id, factId.toFactId()) }
+            .findById(StoreName(storeName), factId.toFactId())
             .toResponse()
 
     @POST
@@ -43,11 +42,8 @@ class QueryResource(
         @Valid factQueryHttp: FactQueryHttp
     ): Response =
         store
-            .resolveStoreOrThrow(storeName)
-            .let { metadata ->
-                store.findByTagQuery(metadata.id, factQueryHttp.toTagQuery())
-                    .toResponse()
-            }
+            .findByTagQuery(StoreName(storeName), factQueryHttp.toTagQuery())
+            .toResponse()
 
     @GET
     @Produces(APPLICATION_JSON)
@@ -58,10 +54,7 @@ class QueryResource(
         @PathParam("subjectId") subjectId: String,
     ): Response =
         store
-            .resolveStoreOrThrow(storeName)
-            .let { metadata ->
-                store.findBySubject(metadata.id, SubjectRef(subjectType, subjectId))
-            }
+            .findBySubject(StoreName(storeName), SubjectRef(subjectType, subjectId))
             .toResponse()
 
     @GET
@@ -73,16 +66,13 @@ class QueryResource(
         @QueryParam("to") to: Instant? = null,
     ): Response =
         store
-            .resolveStoreOrThrow(storeName)
-            .let { metadata ->
-                store.findInTimeRange(
-                    storeId = metadata.id,
-                    TimeRange(
-                        start = from ?: Instant.MIN,
-                        end = to ?: Instant.now()
-                    )
+            .findInTimeRange(
+                storeName = StoreName(storeName),
+                TimeRange(
+                    start = from ?: Instant.MIN,
+                    end = to ?: Instant.now()
                 )
-            }
+            )
             .toResponse()
 
 }
@@ -115,6 +105,3 @@ private fun FindByTagQueryResult.toResponse(): Response {
         is FindByTagQueryResult.StoreNotFound -> Response.status(NOT_FOUND).build()
     }
 }
-
-private fun List<Fact>.toResponse(): Response =
-    Response.ok(map { it.toFactHttp() }).build()

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/StreamResource.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/StreamResource.kt
@@ -14,7 +14,6 @@ import java.util.*
 
 @Path("/v1/stores/{storeName}/facts/stream")
 class StreamResource(
-    private val finder: StoreFinder,
     private val factStore: FactStore,
 ) {
 
@@ -26,15 +25,11 @@ class StreamResource(
         @QueryParam("after") after: UUID? = null,
         @QueryParam("from") from: String? = null,
     ): Flow<FactHttp> =
-        finder
-            .resolveStoreOrThrow(storeName)
-            .let { metadata ->
-                val streamResult = factStore.stream(
-                    storeId = metadata.id,
-                    streamingOptions = buildStreamingOptions(after, from?.lowercase(Locale.ENGLISH))
-                )
-                streamResult.toResponse()
-            }
+        factStore.stream(
+            storeName = StoreName(storeName),
+            streamingOptions = buildStreamingOptions(after, from?.lowercase(Locale.ENGLISH))
+        )
+            .toResponse()
 
 
     private fun buildStreamingOptions(after: UUID?, from: String?): StreamingOptions {

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/extensions.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/extensions.kt
@@ -7,8 +7,8 @@ import io.factstore.core.AppendResult
 import io.factstore.core.Fact
 import io.factstore.core.FactId
 import io.factstore.core.FactPayload
-import io.factstore.core.StoreId
 import io.factstore.core.IdempotencyKey
+import io.factstore.core.StoreName
 import io.factstore.core.SubjectRef
 import io.factstore.core.TagOnlyQueryItem
 import io.factstore.core.TagQuery
@@ -25,8 +25,8 @@ fun AppendResult.toResponse(): Response {
     return Response.ok(this::class.qualifiedName).build()
 }
 
-fun AppendHttpRequest.toAppendRequest(storeId: StoreId): AppendRequest = AppendRequest(
-    storeId = storeId,
+fun AppendHttpRequest.toAppendRequest(storeName: StoreName): AppendRequest = AppendRequest(
+    storeName = storeName,
     facts = facts.toFacts(),
     idempotencyKey = idempotencyKey?.let { IdempotencyKey(it) } ?: IdempotencyKey(),
     condition = condition?.toAppendCondition() ?: AppendCondition.None

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/utils.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/utils.kt
@@ -1,14 +1,8 @@
 package io.factstore.server.http
 
-import io.factstore.core.StoreFinder
-import io.factstore.core.StoreName
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
-
-
-suspend fun StoreFinder.resolveStoreOrThrow(name: String) =
-    findByName(StoreName(name)) ?: throw FactstoreNotFound("Fact store with name $name not found")
 
 
 class FactstoreNotFound(message: String) : RuntimeException(message)

--- a/factstore-specification/src/main/kotlin/io/factstore/core/AppendRequest.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/AppendRequest.kt
@@ -23,7 +23,7 @@ value class IdempotencyKey(val value: UUID = UUID.randomUUID())
  * and conditional append semantics. All facts contained in the request are
  * processed atomically.
  *
- * @property storeId the fact store to which to append the facts to
+ * @property storeName the store to which to append the facts to
  * @property facts the facts to append
  * @property idempotencyKey the key used to ensure idempotent processing
  * @property condition an optional condition that must be satisfied for the
@@ -34,7 +34,7 @@ value class IdempotencyKey(val value: UUID = UUID.randomUUID())
  * @author Domenic Cassisi
  */
 data class AppendRequest(
-    val storeId: StoreId,
+    val storeName: StoreName,
     val facts: List<Fact>,
     val idempotencyKey: IdempotencyKey,
     val condition: AppendCondition = AppendCondition.None

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactAppender.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactAppender.kt
@@ -22,7 +22,7 @@ interface FactAppender {
      * @throws FactStoreException if the fact violates store invariants or
      *         the request is invalid
      */
-    suspend fun append(storeId: StoreId, fact: Fact): AppendResult
+    suspend fun append(storeName: StoreName, fact: Fact): AppendResult
 
     /**
      * Appends multiple facts to the store atomically.
@@ -33,7 +33,7 @@ interface FactAppender {
      * @throws FactStoreException if any fact violates store invariants or
      *         the request is invalid
      */
-    suspend fun append(storeId: StoreId, facts: List<Fact>): AppendResult
+    suspend fun append(storeName: StoreName, facts: List<Fact>): AppendResult
 
     /**
      * Appends facts using an explicit append request.

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactFinder.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactFinder.kt
@@ -12,57 +12,76 @@ package io.factstore.core
 interface FactFinder {
 
     /**
-     * Finds a fact by its unique identifier.
+     * Retrieves a specific fact by its unique identifier within a named store.
      *
-     * @param factId the identifier of the fact
-     * @return the fact if it exists, or `null` otherwise
+     * This method is the primary way to access a single event when the [FactId] is known.
+     * Because store resolution and fact lookup are distinct operations, the result
+     * explicitly distinguishes between a missing store and a missing fact.
+     *
+     * @param storeName the logical name of the store
+     * @param factId the unique identifier of the fact to retrieve.
+     * @return a [FindByIdResult] which can be handled using a `when` expression:
+     * - [FindByIdResult.Found]: contains the requested [Fact].
+     * - [FindByIdResult.NotFound]: the store exists, but the fact ID is unknown.
+     * - [FindByIdResult.StoreNotFound]: the provided [storeName] does not exist.
      */
-    suspend fun findById(storeId: StoreId, factId: FactId): FindByIdResult
+    suspend fun findById(storeName: StoreName, factId: FactId): FindByIdResult
 
     /**
-     * Checks whether a fact with the given identifier exists.
+     * Checks for the existence of a specific fact within a named store.
      *
-     * @param factId the identifier of the fact
-     * @return `true` if a fact with the given identifier exists, `false` otherwise
+     * Use this lightweight check when you only need to verify presence without
+     * fetching the full fact payload.
+     *
+     * @param storeName the logical name of the store.
+     * @param factId the unique identifier of the fact.
+     * @return an [ExistsByIdResult] indicating if the fact was [ExistsByIdResult.Exists],
+     *         [ExistsByIdResult.DoesNotExist], or if the [ExistsByIdResult.StoreNotFound].
      */
-    suspend fun existsById(storeId: StoreId, factId: FactId): ExistsByIdResult
+    suspend fun existsById(storeName: StoreName, factId: FactId): ExistsByIdResult
 
     /**
-     * Finds all facts created within the given time range.
+     * Retrieves a chronological list of facts appended within a specific time window.
      *
-     * The range is inclusive of both start and end timestamps.
+     * This method is useful for querying recent events or performing time-based analyses.
      *
-     * @param timeRange the time range to cover
-     * @return the list of facts created within the specified time range, or an error if the factstore doesn't exist
+     * @param storeName the logical name of the store.
+     * @param timeRange the inclusive temporal boundaries for the search.
+     * @return a [FindInTimeRangeResult] containing the list of facts, or
+     *         [FindInTimeRangeResult.StoreNotFound] if the store does not exist.
      */
-    suspend fun findInTimeRange(storeId: StoreId, timeRange: TimeRange): FindInTimeRangeResult
+    suspend fun findInTimeRange(storeName: StoreName, timeRange: TimeRange): FindInTimeRangeResult
 
     /**
-     * Finds all facts associated with the given subject.
+     * Retrieves the complete history of facts associated with a specific subject.
      *
+     * @param storeName the logical name of the store.
      * @param subjectRef the subject reference
-     * @return the list of facts associated with the subject, or an error if the factstore doesn't exist
+     * @return a [FindBySubjectResult.Found] containing the stream of facts for this subject,
+     *         or [FindBySubjectResult.StoreNotFound] if the store is missing.
      */
-    suspend fun findBySubject(storeId: StoreId, subjectRef: SubjectRef): FindBySubjectResult
+    suspend fun findBySubject(storeName: StoreName, subjectRef: SubjectRef): FindBySubjectResult
 
     /**
-     * Finds all facts that match the given set of tags.
+     * Finds facts that match at least one of the provided tags (OR logic).
      *
-     * The provided tags are interpreted as an OR match requirement.
-     *
-     * @param tags the list of tag key-value pairs
-     * @return the list of facts matching the specified tags, or an error if the factstore doesn't exist
+     * @param storeName the logical name of the store.
+     * @param tags a list of key-value pairs to match against.
+     * @return a [FindByTagsResult.Found] with matching facts, or
+     *         [FindByTagsResult.StoreNotFound] if the store does not exist.
      */
-    suspend fun findByTags(storeId: StoreId, tags: List<Pair<TagKey, TagValue>>): FindByTagsResult
+    suspend fun findByTags(storeName: StoreName, tags: List<Pair<TagKey, TagValue>>): FindByTagsResult
 
     /**
-     * Finds all facts that match the given tag query.
+     * Performs an expressive search for facts using a structured tag query.
      *
      * Tag queries allow more expressive matching semantics than simple
      * key-value pairs.
      *
+     * @param storeName the logical name of the store.
      * @param query the tag query
-     * @return the list of facts matching the query, or an error if the factstore doesn't exist
+     * @return a [FindByTagQueryResult.Found] containing the filtered facts, or
+     *         [FindByTagQueryResult.StoreNotFound] if the store name cannot be resolved.
      */
-    suspend fun findByTagQuery(storeId: StoreId, query: TagQuery): FindByTagQueryResult
+    suspend fun findByTagQuery(storeName: StoreName, query: TagQuery): FindByTagQueryResult
 }

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactStreamer.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactStreamer.kt
@@ -22,13 +22,13 @@ interface FactStreamer {
      * The returned [Flow] emits facts incrementally and may continue emitting
      * new facts as they are appended to the store.
      *
-     *
+     * @param storeName the store from which to stream facts
      * @param streamingOptions configuration options controlling how facts
      * are streamed
      * @return a cold [Flow] emitting facts that match the streaming criteria,
      * or an error result if the fact store does not exist or the start position is invalid
      */
-    suspend fun stream(storeId: StoreId, streamingOptions: StreamingOptions): StreamResult
+    suspend fun stream(storeName: StoreName, streamingOptions: StreamingOptions): StreamResult
 
     /**
      * Streams all facts from the beginning of the store.
@@ -38,7 +38,7 @@ interface FactStreamer {
      *
      * @return a cold [Flow] emitting all facts in order
      */
-    suspend fun stream(storeId: StoreId) = stream(storeId, StreamingOptions())
+    suspend fun stream(storeName: StoreName) = stream(storeName, StreamingOptions())
 
 }
 

--- a/factstore-specification/src/test/kotlin/io/factstore/core/AppendRequestTest.kt
+++ b/factstore-specification/src/test/kotlin/io/factstore/core/AppendRequestTest.kt
@@ -25,7 +25,7 @@ class AppendRequestTest {
 
         assertThatThrownBy {
             AppendRequest(
-                storeId = StoreId.generate(),
+                storeName = StoreName("test-store"),
                 facts = listOf(fact1, fact2),
                 idempotencyKey = IdempotencyKey(),
                 condition = AppendCondition.None
@@ -34,7 +34,7 @@ class AppendRequestTest {
 
         val fact3 = fact1.copy(id = FactId.generate())
         AppendRequest(
-            storeId = StoreId.generate(),
+            storeName = StoreName("test-store"),
             facts = listOf(fact1, fact3), // no duplicated fact id
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.None

--- a/factstore-testing/src/main/kotlin/io/factstore/testing/AbstractFactStoreTest.kt
+++ b/factstore-testing/src/main/kotlin/io/factstore/testing/AbstractFactStoreTest.kt
@@ -17,7 +17,8 @@ import kotlin.system.measureTimeMillis
 
 abstract class AbstractFactStoreTest {
 
-    private var storeId: StoreId = StoreId.generate()
+    private var testStore = StoreName("default-test-store")
+    private val nonExistingStore = StoreName("non-existing-store")
     private lateinit var store: FactStore
 
     abstract fun reset()
@@ -26,14 +27,13 @@ abstract class AbstractFactStoreTest {
 
 
     @BeforeEach
-    fun clearEventStore() = runBlocking {
+    fun clearEventStore(): Unit = runBlocking {
         store = initializeFactStore()
         reset()
-        val createStoreRequest = CreateStoreRequest(storeName = StoreName("test-factstore"))
+        val createStoreRequest = CreateStoreRequest(storeName = testStore)
         val result = store.handle(createStoreRequest)
 
         assertThat(result).isInstanceOf(CreateStoreResult.Created::class.java)
-        storeId = (result as CreateStoreResult.Created).id
     }
 
 
@@ -90,17 +90,17 @@ abstract class AbstractFactStoreTest {
             appendedAt = createdAt
         )
 
-        store.append(storeId, fact)
+        store.append(testStore, fact)
 
-        store.stream(storeId).let { (it as StreamResult.FactStream).stream }.take(1).collect {
+        store.stream(testStore).let { (it as StreamResult.FactStream).stream }.take(1).collect {
             println("Streamed fact: $it")
         }
 
         // validate existence of fact
-        assertThat(store.existsById(storeId, id)).isEqualTo(ExistsByIdResult.Exists)
+        assertThat(store.existsById(testStore, id)).isEqualTo(ExistsByIdResult.Exists)
 
         // find fact by ID
-        val findResult = store.findById(storeId, id)
+        val findResult = store.findById(testStore, id)
         assertThat(findResult).isInstanceOf(FindByIdResult.Found::class.java)
         val foundFact = (findResult as FindByIdResult.Found).fact
         assertThat(foundFact).isEqualTo(fact)
@@ -109,15 +109,14 @@ abstract class AbstractFactStoreTest {
     @Test
     fun testExists(): Unit = runBlocking {
         val nonExistingFactId = FactId.generate()
-        assertThat(store.existsById(storeId, nonExistingFactId)).isEqualTo(ExistsByIdResult.DoesNotExist)
+        assertThat(store.existsById(testStore, nonExistingFactId)).isEqualTo(ExistsByIdResult.DoesNotExist)
     }
 
     @Test
     fun testExistsForNonExistingFactstore(): Unit = runBlocking {
-        val nonExistingFactstore = StoreId.generate()
         assertThat(
             store.existsById(
-                nonExistingFactstore,
+                nonExistingStore,
                 FactId.generate()
             )
         ).isEqualTo(ExistsByIdResult.StoreNotFound)
@@ -125,8 +124,7 @@ abstract class AbstractFactStoreTest {
 
     @Test
     fun testFindByIdWithNonExistingFactStore(): Unit = runBlocking {
-        val nonExistingFactstore = StoreId.generate()
-        val result = store.findById(nonExistingFactstore, FactId.generate())
+        val result = store.findById(nonExistingStore, FactId.generate())
         assertThat(result).isInstanceOf(FindByIdResult.StoreNotFound::class.java)
     }
 
@@ -168,11 +166,11 @@ abstract class AbstractFactStoreTest {
         )
 
         // Append all three
-        store.append(storeId, listOf(fact1, fact2, fact3))
+        store.append(testStore, listOf(fact1, fact2, fact3))
 
         // Query range covering fact1 + fact2, but excluding fact3
         val result = store.findInTimeRange(
-            storeId = storeId,
+            storeName = testStore,
             TimeRange(
                 start = now.minusSeconds(120),
                 end = now.plusSeconds(10)
@@ -188,7 +186,7 @@ abstract class AbstractFactStoreTest {
     @Test
     fun testFindInTimeRangeForNonExistingStore(): Unit = runBlocking {
         val result = store.findInTimeRange(
-            storeId = StoreId.generate(),
+            storeName = nonExistingStore,
             TimeRange(
                 start = Instant.now().minusSeconds(120),
                 end = Instant.now().plusSeconds(10)
@@ -215,7 +213,7 @@ abstract class AbstractFactStoreTest {
 
         // append fact1
         val appendRequestWithEmptySubjectCondition = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact1),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.ExpectedLastFact(
@@ -246,7 +244,7 @@ abstract class AbstractFactStoreTest {
         )
 
         val appendRequestWithFirstFactSubjectCondition = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact2),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.ExpectedLastFact(
@@ -266,7 +264,7 @@ abstract class AbstractFactStoreTest {
         // this simulates two concurrent/conflicting append requests
         val fact3 = fact2.copy(id = FactId.generate())
         val appendRequestWithViolatingSubjectCondition = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact3),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.ExpectedLastFact(
@@ -324,7 +322,7 @@ abstract class AbstractFactStoreTest {
         )
 
         val appendRequest = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact1, fact2, fact3),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.ExpectedMultiSubjectLastFact(
@@ -383,30 +381,30 @@ abstract class AbstractFactStoreTest {
 
         val factsToAppend = listOf(fact1, fact2, fact3)
 
-        store.append(storeId, factsToAppend)
+        store.append(testStore, factsToAppend)
 
-        val aliceResult = store.findBySubject(storeId, SubjectRef("USER", "ALICE"))
+        val aliceResult = store.findBySubject(testStore, SubjectRef("USER", "ALICE"))
         assertThat(aliceResult).isInstanceOf(FindBySubjectResult.Found::class.java)
         assertThat((aliceResult as FindBySubjectResult.Found).facts)
             .containsExactly(fact1, fact3)
 
-        val bobResult = store.findBySubject(storeId, SubjectRef("USER", "BOB"))
+        val bobResult = store.findBySubject(testStore, SubjectRef("USER", "BOB"))
         assertThat(bobResult).isInstanceOf(FindBySubjectResult.Found::class.java)
         assertThat((bobResult as FindBySubjectResult.Found).facts)
             .containsExactly(fact2)
 
-        val peterResult = store.findBySubject(storeId, SubjectRef("USER", "PETER"))
+        val peterResult = store.findBySubject(testStore, SubjectRef("USER", "PETER"))
         assertThat(peterResult).isInstanceOf(FindBySubjectResult.Found::class.java)
         assertThat((peterResult as FindBySubjectResult.Found).facts).isEmpty()
 
-        val unknownResult = store.findBySubject(storeId, SubjectRef("UNKNOWN", "UNKNOWN"))
+        val unknownResult = store.findBySubject(testStore, SubjectRef("UNKNOWN", "UNKNOWN"))
         assertThat(unknownResult).isInstanceOf(FindBySubjectResult.Found::class.java)
         assertThat((unknownResult as FindBySubjectResult.Found).facts).isEmpty()
     }
 
     @Test
     fun findBySubjectForNonExistingFactstore(): Unit = runBlocking {
-        val result = store.findBySubject(StoreId.generate(), SubjectRef("SOME_TYPE", "SOME_ID"))
+        val result = store.findBySubject(nonExistingStore, SubjectRef("SOME_TYPE", "SOME_ID"))
         assertThat(result).isInstanceOf(FindBySubjectResult.StoreNotFound::class.java)
     }
 
@@ -441,12 +439,12 @@ abstract class AbstractFactStoreTest {
 
         val factsToAppend = listOf(fact1, fact2)
 
-        store.append(storeId, factsToAppend)
+        store.append(testStore, factsToAppend)
 
-        assertThat(store.findById(storeId, fact1Id)).isInstanceOf(FindByIdResult.Found::class.java)
-        assertThat((store.findById(storeId, fact1Id) as FindByIdResult.Found).fact).isEqualTo(fact1)
-        assertThat(store.findById(storeId, fact2Id)).isInstanceOf(FindByIdResult.Found::class.java)
-        assertThat((store.findById(storeId, fact2Id) as FindByIdResult.Found).fact).isEqualTo(fact2)
+        assertThat(store.findById(testStore, fact1Id)).isInstanceOf(FindByIdResult.Found::class.java)
+        assertThat((store.findById(testStore, fact1Id) as FindByIdResult.Found).fact).isEqualTo(fact1)
+        assertThat(store.findById(testStore, fact2Id)).isInstanceOf(FindByIdResult.Found::class.java)
+        assertThat((store.findById(testStore, fact2Id) as FindByIdResult.Found).fact).isEqualTo(fact2)
     }
 
     @Test
@@ -490,39 +488,39 @@ abstract class AbstractFactStoreTest {
             tags = mapOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("us"))
         )
 
-        store.append(storeId, listOf(fact1, fact2, fact3))
+        store.append(testStore, listOf(fact1, fact2, fact3))
 
         // --- Query 1: Find all role=admin (OR semantics → fact1 + fact3)
-        val adminResult = store.findByTags(storeId, listOf(TagKey("role") to TagValue("admin")))
+        val adminResult = store.findByTags(testStore, listOf(TagKey("role") to TagValue("admin")))
         assertThat(adminResult).isInstanceOf(FindByTagsResult.Found::class.java)
         assertThat((adminResult as FindByTagsResult.Found).facts).containsExactly(fact1, fact3)
 
         // --- Query 2: Find all region=us (OR semantics → fact2 + fact3)
-        val usResult = store.findByTags(storeId, listOf(TagKey("region") to TagValue("us")))
+        val usResult = store.findByTags(testStore, listOf(TagKey("region") to TagValue("us")))
         assertThat(usResult).isInstanceOf(FindByTagsResult.Found::class.java)
         assertThat((usResult as FindByTagsResult.Found).facts).containsExactly(fact2, fact3)
 
         // --- Query 3: Find all role=admin OR region=eu (OR semantics → fact1 + fact3)
         val adminOrEuResult = store.findByTags(
-            storeId,
+            testStore,
             listOf(TagKey("role") to TagValue("admin"), TagKey("region") to TagValue("eu"))
         )
         assertThat(adminOrEuResult).isInstanceOf(FindByTagsResult.Found::class.java)
         assertThat((adminOrEuResult as FindByTagsResult.Found).facts).containsExactly(fact1, fact3)
 
         // --- Query 4: Non-existent tag → empty
-        val noFactsResult = store.findByTags(storeId, listOf(TagKey("region") to TagValue("asia")))
+        val noFactsResult = store.findByTags(testStore, listOf(TagKey("region") to TagValue("asia")))
         assertThat(noFactsResult).isInstanceOf(FindByTagsResult.Found::class.java)
         assertThat((noFactsResult as FindByTagsResult.Found).facts).isEmpty()
 
         // --- Query 5: Union of all queries (just to validate coverage)
 
-        val fact1Loaded = store.findById(storeId, fact1.id)
+        val fact1Loaded = store.findById(testStore, fact1.id)
         assertThat(fact1Loaded).isInstanceOf(FindByIdResult.Found::class.java)
         println(fact1Loaded)
 
         val allFactsResult = store.findByTags(
-            storeId,
+            testStore,
             listOf(
                 TagKey("role") to TagValue("admin"),
                 TagKey("role") to TagValue("user"),
@@ -537,7 +535,7 @@ abstract class AbstractFactStoreTest {
     @Test
     fun testFindByTagsWithNonExistingFactstore(): Unit = runBlocking {
         val result = store.findByTags(
-            StoreId.generate(),
+            nonExistingStore,
             listOf(TagKey("region") to TagValue("asia"))
         )
 
@@ -553,7 +551,7 @@ abstract class AbstractFactStoreTest {
 
         // Start streaming from beginning
         val streamJob = launch {
-            store.stream(storeId)
+            store.stream(testStore)
                 .let { (it as StreamResult.FactStream).stream }
                 .take(3)
                 .collect {
@@ -570,9 +568,9 @@ abstract class AbstractFactStoreTest {
         val fact3 = createUserFact("CHARLIE", "Charlie", "admin", "us")
 
         // Append
-        store.append(storeId, fact1)
-        store.append(storeId, fact2)
-        store.append(storeId, fact3)
+        store.append(testStore, fact1)
+        store.append(testStore, fact2)
+        store.append(testStore, fact3)
 
         // Wait deterministically until 3 facts are received
         firstThreeReceived.await()
@@ -584,7 +582,7 @@ abstract class AbstractFactStoreTest {
         // ---- Test StartPosition.After ----
 
         val streamedEvents = store.stream(
-            storeId,
+            testStore,
             StreamingOptions(startPosition = StartPosition.After(fact1.id))
         ).let { (it as StreamResult.FactStream).stream }
             .take(2)
@@ -597,7 +595,7 @@ abstract class AbstractFactStoreTest {
         val nonExistingFactId = FactId.generate()
 
         val streamResult = store.stream(
-            storeId,
+            testStore,
             StreamingOptions(startPosition = StartPosition.After(nonExistingFactId))
         )
 
@@ -612,8 +610,8 @@ abstract class AbstractFactStoreTest {
         val initialFact1 = createUserFact("ALICE", "Alice", "admin", "eu")
         val initialFact2 = createUserFact("BOB", "Bob", "user", "us")
 
-        store.append(storeId, initialFact1)
-        store.append(storeId, initialFact2)
+        store.append(testStore, initialFact1)
+        store.append(testStore, initialFact2)
 
         val received = mutableListOf<Fact>()
         val receivedLatch = CompletableDeferred<Unit>()
@@ -622,7 +620,7 @@ abstract class AbstractFactStoreTest {
         // Start stream from END (should NOT see initialFact1/2)
         val job = launch {
             store.stream(
-                storeId,
+                testStore,
                 StreamingOptions(startPosition = StartPosition.End)
             )
                 .let { (it as StreamResult.FactStream).stream }
@@ -643,8 +641,8 @@ abstract class AbstractFactStoreTest {
         val newFact1 = createUserFact("CHARLIE", "Charlie", "admin", "us")
         val newFact2 = createUserFact("DAVID", "David", "user", "eu")
 
-        store.append(storeId, newFact1)
-        store.append(storeId, newFact2)
+        store.append(testStore, newFact1)
+        store.append(testStore, newFact2)
 
         // Wait deterministically until 2 facts received
         receivedLatch.await()
@@ -676,7 +674,7 @@ abstract class AbstractFactStoreTest {
 
     @Test
     fun testStreamingNonExistingFactstore(): Unit = runBlocking {
-        val streamResult = store.stream(StoreId.generate())
+        val streamResult = store.stream(nonExistingStore)
         assertThat(streamResult).isInstanceOf(StreamResult.StoreNotFound::class.java)
     }
 
@@ -724,7 +722,7 @@ abstract class AbstractFactStoreTest {
             tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
         )
 
-        store.append(storeId, listOf(fact1, fact2, fact3))
+        store.append(testStore, listOf(fact1, fact2, fact3))
 
 
         // Test 1: Query with a single tag (username = "bob")
@@ -737,7 +735,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val bobFacts = store.findByTagQuery(storeId, bobQuery)
+        val bobFacts = store.findByTagQuery(testStore, bobQuery)
         assertThat(bobFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((bobFacts as FindByTagQueryResult.Found).facts).containsExactly(fact2)
 
@@ -751,7 +749,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val multipleTagsFacts = store.findByTagQuery(storeId, multipleTagsQuery)
+        val multipleTagsFacts = store.findByTagQuery(testStore, multipleTagsQuery)
         assertThat(multipleTagsFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((multipleTagsFacts as FindByTagQueryResult.Found).facts).containsExactly(fact2)
 
@@ -765,7 +763,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val noMatchFacts = store.findByTagQuery(storeId, noMatchQuery)
+        val noMatchFacts = store.findByTagQuery(testStore, noMatchQuery)
         assertThat(noMatchFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((noMatchFacts as FindByTagQueryResult.Found).facts).isEmpty()
 
@@ -779,7 +777,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val multipleTypesFacts = store.findByTagQuery(storeId, multipleTypesQuery)
+        val multipleTypesFacts = store.findByTagQuery(testStore, multipleTypesQuery)
         assertThat(multipleTypesFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((multipleTypesFacts as FindByTagQueryResult.Found).facts).containsExactly(fact2)
 
@@ -793,7 +791,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val complexFacts = store.findByTagQuery(storeId, complexQuery)
+        val complexFacts = store.findByTagQuery(testStore, complexQuery)
         assertThat(complexFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((complexFacts as FindByTagQueryResult.Found).facts).containsExactly(fact2)
 
@@ -807,7 +805,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val noMatchingTagFacts = store.findByTagQuery(storeId, noMatchingTagQuery)
+        val noMatchingTagFacts = store.findByTagQuery(testStore, noMatchingTagQuery)
         assertThat(noMatchingTagFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((noMatchingTagFacts as FindByTagQueryResult.Found).facts).isEmpty()
 
@@ -821,7 +819,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val noMatchingTypeFacts = store.findByTagQuery(storeId, noMatchingTypeQuery)
+        val noMatchingTypeFacts = store.findByTagQuery(testStore, noMatchingTypeQuery)
         assertThat(noMatchingTypeFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((noMatchingTypeFacts as FindByTagQueryResult.Found).facts).isEmpty()
 
@@ -835,7 +833,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val tagsNoFacts = store.findByTagQuery(storeId, tagsNoFactsQuery)
+        val tagsNoFacts = store.findByTagQuery(testStore, tagsNoFactsQuery)
         assertThat(tagsNoFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((tagsNoFacts as FindByTagQueryResult.Found).facts).isEmpty()
 
@@ -849,7 +847,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val differentTagsFacts = store.findByTagQuery(storeId, differentTagsQuery)
+        val differentTagsFacts = store.findByTagQuery(testStore, differentTagsQuery)
         assertThat(differentTagsFacts).isInstanceOf(FindByTagQueryResult.Found::class.java)
         assertThat((differentTagsFacts as FindByTagQueryResult.Found).facts).containsExactly(fact3)
 
@@ -888,7 +886,7 @@ abstract class AbstractFactStoreTest {
             tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
         )
 
-        store.append(storeId, listOf(fact1, fact2, fact3))
+        store.append(testStore, listOf(fact1, fact2, fact3))
 
         // Query for facts with types "USER_CREATED" or "USER_UPDATED" and with tags "username" = "alice"
         val query = TagQuery(
@@ -900,7 +898,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val result = store.findByTagQuery(storeId, query)
+        val result = store.findByTagQuery(testStore, query)
 
         // Expecting fact1 only (username = alice, type = "USER_CREATED")
         assertThat(result).isInstanceOf(FindByTagQueryResult.Found::class.java)
@@ -940,7 +938,7 @@ abstract class AbstractFactStoreTest {
             tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
         )
 
-        store.append(storeId, listOf(fact1, fact2, fact3))
+        store.append(testStore, listOf(fact1, fact2, fact3))
 
         // Query for facts with type "USER_CREATED" or "USER_UPDATED", tagged with "username" = "bob"
         val query = TagQuery(
@@ -956,7 +954,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val result = store.findByTagQuery(storeId, query)
+        val result = store.findByTagQuery(testStore, query)
 
         // Expecting fact2 (username = bob, region = us, type = USER_UPDATED)
         // Expecting fact3 (region = us, type = USER_CREATED, but no username filter for 'bob')
@@ -998,7 +996,7 @@ abstract class AbstractFactStoreTest {
             tags = mapOf(TagKey("username") to TagValue("charlie"), TagKey("region") to TagValue("us"))
         )
 
-        store.append(storeId, listOf(fact1, fact2, fact3))
+        store.append(testStore, listOf(fact1, fact2, fact3))
 
         // Query with multiple query items
         val query = TagQuery(
@@ -1014,7 +1012,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val result = store.findByTagQuery(storeId, query)
+        val result = store.findByTagQuery(testStore, query)
 
         // Expecting fact2 (username = bob, region = us, type = USER_UPDATED)
         // Expecting fact1 (username = alice, region = eu, type = USER_CREATED)
@@ -1035,7 +1033,7 @@ abstract class AbstractFactStoreTest {
             tags = mapOf(TagKey("username") to TagValue("alice"), TagKey("region") to TagValue("eu"))
         )
 
-        store.append(storeId, listOf(fact1))
+        store.append(testStore, listOf(fact1))
 
         // Query for facts with a non-matching type and tag
         val query = TagQuery(
@@ -1047,7 +1045,7 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val result = store.findByTagQuery(storeId, query)
+        val result = store.findByTagQuery(testStore, query)
 
         // Expecting no facts because no fact matches the query
         assertThat(result).isInstanceOf(FindByTagQueryResult.Found::class.java)
@@ -1081,11 +1079,11 @@ abstract class AbstractFactStoreTest {
         // Append all events to the store (in chunks to avoid exceeding byte limit in FoundationDB)
         events
             .chunked(500)
-            .forEach { store.append(storeId, it) }
+            .forEach { store.append(testStore, it) }
 
         // append a few more events
         store.append(
-            storeId,
+            testStore,
             Fact(
                 id = FactId.generate(),
                 subjectRef = SubjectRef(
@@ -1114,16 +1112,16 @@ abstract class AbstractFactStoreTest {
             )
         )
 
-        val result = store.findByTagQuery(storeId, query)
+        val result = store.findByTagQuery(testStore, query)
 
 
         measureTimeMillis {
-            store.findByTagQuery(storeId, query)
+            store.findByTagQuery(testStore, query)
         }.also { println(it) }
 
         measureTimeMillis {
             store.findByTagQuery(
-                storeId,
+                testStore,
                 TagQuery(
                     listOf(
                         TagTypeItem(
@@ -1156,7 +1154,7 @@ abstract class AbstractFactStoreTest {
     fun testFindByTagQueryWithNonExistingFactstore(): Unit = runBlocking {
         assertThat(
             store.findByTagQuery(
-                StoreId.generate(),
+                nonExistingStore,
                 TagQuery(
                     listOf(
                         TagTypeItem(
@@ -1203,7 +1201,7 @@ abstract class AbstractFactStoreTest {
         println("appending $fact1Id")
         store.append(
             AppendRequest(
-                storeId = storeId,
+                storeName = testStore,
                 facts = listOf(fact1),
                 idempotencyKey = IdempotencyKey(),
                 condition = AppendCondition.TagQueryBased(
@@ -1229,7 +1227,7 @@ abstract class AbstractFactStoreTest {
         )
 
         val appendRequest2 = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact2),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.TagQueryBased(
@@ -1241,7 +1239,7 @@ abstract class AbstractFactStoreTest {
         store.append(appendRequest2).also { assertThat(it).isInstanceOf(AppendResult.Appended::class.java) }
 
         val appendRequest3 = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact2.copy(id = FactId.generate())),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.TagQueryBased(
@@ -1282,7 +1280,7 @@ abstract class AbstractFactStoreTest {
 
         println("appending $fact3Id")
         val appendRequest4 = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact3),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.TagQueryBased(
@@ -1308,7 +1306,7 @@ abstract class AbstractFactStoreTest {
         )
 
         val appendRequestThatShouldAppendFact4 = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact4),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.TagQueryBased(
@@ -1331,10 +1329,11 @@ abstract class AbstractFactStoreTest {
         // two fact store instances should be treated as two logical database instances
         // even if they share underlying infrastructure, like the same FoundationDB cluster
 
-        val storeId1 = store.handle(CreateStoreRequest(StoreName("store-1")))
-            .let { it as CreateStoreResult.Created }.id
-        val storeId2 = store.handle(CreateStoreRequest(StoreName("store-2")))
-            .let { it as CreateStoreResult.Created }.id
+        val storeName1 = StoreName("store-1")
+        val storeName2 = StoreName("store-2")
+
+        store.handle(CreateStoreRequest(storeName1))
+        store.handle(CreateStoreRequest(storeName2))
 
         val fact1 = Fact(
             id = FactId.generate(),
@@ -1360,20 +1359,19 @@ abstract class AbstractFactStoreTest {
             tags = emptyMap()
         )
 
-        store.append(storeId1, fact1)
-        store.append(storeId2, fact2)
+        store.append(storeName1, fact1)
+        store.append(storeName2, fact2)
 
-        assertThat(store.existsById(storeId1, fact1.id)).isEqualTo(ExistsByIdResult.Exists)
-        assertThat(store.existsById(storeId1, fact2.id)).isEqualTo(ExistsByIdResult.DoesNotExist)
+        assertThat(store.existsById(storeName1, fact1.id)).isEqualTo(ExistsByIdResult.Exists)
+        assertThat(store.existsById(storeName1, fact2.id)).isEqualTo(ExistsByIdResult.DoesNotExist)
 
-        assertThat(store.existsById(storeId2, fact1.id)).isEqualTo(ExistsByIdResult.DoesNotExist)
-        assertThat(store.existsById(storeId2, fact2.id)).isEqualTo(ExistsByIdResult.Exists)
+        assertThat(store.existsById(storeName2, fact1.id)).isEqualTo(ExistsByIdResult.DoesNotExist)
+        assertThat(store.existsById(storeName2, fact2.id)).isEqualTo(ExistsByIdResult.Exists)
     }
 
     @Test
     fun testAppendWithoutFactStore(): Unit = runBlocking {
-        val storeId = StoreId.generate()
-        val result = store.append(storeId, createUserFact("TEST", "Test User", "user", "eu"))
+        val result = store.append(nonExistingStore, createUserFact("TEST", "Test User", "user", "eu"))
         assertThat(result).isInstanceOf(AppendResult.StoreNotFound::class.java)
     }
 
@@ -1393,7 +1391,7 @@ abstract class AbstractFactStoreTest {
         )
         val idempotencyKey = IdempotencyKey(UUID.randomUUID())
         val appendRequest = AppendRequest(
-            storeId = storeId,
+            storeName = testStore,
             facts = listOf(fact1),
             idempotencyKey = idempotencyKey,
             condition = AppendCondition.ExpectedLastFact(
@@ -1436,18 +1434,18 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = fact1.copy()
 
-        store.append(storeId, fact1)
+        store.append(testStore, fact1)
 
         assertDuplicateFactIds(
             expected = listOf(factId)
         ) {
-            store.append(storeId, fact2)
+            store.append(testStore, fact2)
         }
 
         assertDuplicateFactIds(
             expected = listOf(factId)
         ) {
-            store.append(storeId, listOf(fact2))
+            store.append(testStore, listOf(fact2))
         }
 
         assertDuplicateFactIds(
@@ -1455,7 +1453,7 @@ abstract class AbstractFactStoreTest {
         ) {
             store.append(
                 AppendRequest(
-                    storeId = storeId,
+                    storeName = testStore,
                     facts = listOf(fact2),
                     idempotencyKey = IdempotencyKey(),
                     condition = AppendCondition.None


### PR DESCRIPTION
Aligns HTTP and Kotlin API by using name instead of ID as the primary store reference. 