### PR TITLE
#145 Initial Draft of FactStore CLI

### DIFF
--- a/factstore-cli/README.md
+++ b/factstore-cli/README.md
@@ -2,3 +2,30 @@
 
 FactStore CLI is a command-line interface tool to interact with FactStore. 
 It allows you to perform various operations such as appending facts, querying facts, and managing the FactStore instance.
+
+## Usage Examples
+
+```bash
+factstore store create orders
+factstore store list
+
+factstore fact append orders order-placed '{"orderId": "12345", "amount": 100.0}'
+
+factstore fact stream orders --from=beginning
+```
+
+
+## Developer Notes
+
+Build the CLI using the following command:
+
+```bash
+./gradlew :factstore-cli:build -Dquarkus.native.enabled=true
+```
+This will generate a native executable in the `build` directory of the `factstore-cli` module. 
+
+You can then run the CLI using the generated executable or define an alias for easier access. For example:
+
+```bash
+alias factstore=$(pwd)/factstore-cli/build/factstore-cli-1.0.0-SNAPSHOT-runner
+```

--- a/factstore-cli/build.gradle.kts
+++ b/factstore-cli/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.allopen)
+    alias(libs.plugins.quarkus)
+}
+
+dependencies {
+    implementation(enforcedPlatform(libs.io.quarkus.platform.quarkus.bom))
+    implementation("io.quarkus:quarkus-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-config-yaml")
+    implementation("io.quarkus:quarkus-hibernate-validator")
+    implementation("io.quarkus:quarkus-picocli")
+    implementation("io.quarkus:quarkus-rest-client-jackson")
+
+    implementation(libs.io.github.oshai.kotlin.logging)
+
+    testImplementation("io.quarkus:quarkus-junit")
+    testImplementation(libs.org.assertj.assertj.core)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+allOpen {
+    annotation("jakarta.ws.rs.Path")
+    annotation("jakarta.enterprise.context.ApplicationScoped")
+    annotation("jakarta.persistence.Entity")
+    annotation("io.quarkus.test.junit.QuarkusTest")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+        javaParameters = true
+    }
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/FactStorePicoliCustomizer.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/FactStorePicoliCustomizer.kt
@@ -1,0 +1,20 @@
+package io.factstore.cli
+import io.factstore.cli.exception.FactStoreExecutionExceptionHandler
+import io.quarkus.picocli.runtime.PicocliCommandLineFactory
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import picocli.CommandLine
+
+
+@ApplicationScoped
+class FactStorePicoliCustomizer(
+    private val exceptionHandler: FactStoreExecutionExceptionHandler
+)  {
+
+    @Produces
+    fun customCommandLine(factory: PicocliCommandLineFactory): CommandLine =
+        factory
+            .create()
+            .setExecutionExceptionHandler(exceptionHandler)
+
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClient.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClient.kt
@@ -1,0 +1,79 @@
+package io.factstore.cli.client
+
+import io.smallrye.mutiny.Multi
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType.APPLICATION_JSON
+import jakarta.ws.rs.core.MediaType.SERVER_SENT_EVENTS
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import java.time.Instant
+import java.util.UUID
+
+@Path("/v1/")
+@RegisterProvider(FactStoreClientExceptionMapper::class)
+interface FactStoreClient {
+
+    @POST
+    @Path("/stores")
+    fun createStore(request: CreateStoreRequest): Response
+
+    @GET
+    @Path("/stores")
+    fun listStores(): List<StoreMetadata>
+
+    @GET
+    @Produces(SERVER_SENT_EVENTS)
+    @Path("/stores/{store}/facts/stream")
+    fun streamFacts(
+        @PathParam("store") storeName: String,
+        @QueryParam("from") from: String?,
+        @QueryParam("after") after: UUID?,
+    ): Multi<FactHttp>
+
+    @POST
+    @Path("/stores/{store}/facts")
+    @Consumes(APPLICATION_JSON)
+    fun appendFact(
+        @PathParam("store") store: String,
+        request: AppendHttpRequest
+    )
+
+}
+
+data class CreateStoreRequest(val name: String)
+
+data class StoreMetadata(
+    val id: String,
+    val name: String,
+    val createdAt: Instant
+)
+
+data class FactHttp(
+    val id: UUID? = null,
+    val type: String,
+    val subjectRef: SubjectRefHttp,
+    val appendedAt: Instant? = null,
+    val payload: FactPayloadHttp,
+    val metadata: Map<String, String> = emptyMap(),
+    val tags: Map<String, String> = emptyMap()
+)
+
+data class FactPayloadHttp(
+    val data: ByteArray,
+)
+
+data class SubjectRefHttp(
+    val type: String,
+    val id: String
+)
+
+data class AppendHttpRequest(
+    val facts: List<FactHttp>,
+    val idempotencyKey: UUID? = UUID.randomUUID(),
+)

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClientExceptionMapper.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClientExceptionMapper.kt
@@ -1,0 +1,34 @@
+package io.factstore.cli.client
+
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper
+
+class FactStoreClientExceptionMapper : ResponseExceptionMapper<FactStoreApiException> {
+
+    override fun toThrowable(response: Response): FactStoreApiException {
+        return runCatching {
+            response.readEntity(ApiError::class.java)
+        }.fold(
+            onSuccess = { apiError ->
+                FactStoreApiException(apiError, response.status)
+            },
+            onFailure = { _ ->
+                FactStoreApiException(null, response.status)
+            }
+        )
+    }
+
+}
+
+data class FactStoreApiException(
+    val apiError: ApiError?,
+    val httpStatus: Int,
+) : RuntimeException()
+
+data class ApiError(
+    val status: String = "Failure",
+    val message: String,
+    val reason: String,
+    val code: Int,
+    val details: Map<String, Any?>? = null,
+)

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClientFactory.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClientFactory.kt
@@ -1,0 +1,17 @@
+package io.factstore.cli.client
+
+import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder
+import jakarta.enterprise.context.ApplicationScoped
+import java.net.URI
+
+@ApplicationScoped
+class FactStoreClientFactory {
+
+    fun create(url: URI): FactStoreClient {
+        return QuarkusRestClientBuilder
+            .newBuilder()
+            .baseUri(url)
+            .build(FactStoreClient::class.java)
+    }
+
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClientProducer.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClientProducer.kt
@@ -1,0 +1,21 @@
+package io.factstore.cli.client
+
+import io.factstore.cli.config.FactStoreConfigResolver
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import picocli.CommandLine
+
+@ApplicationScoped
+class FactStoreClientProducer {
+
+    @Produces
+    @ApplicationScoped
+    fun produceClient(
+        parseResult: CommandLine.ParseResult,
+        resolver: FactStoreConfigResolver,
+        factory: FactStoreClientFactory
+    ): FactStoreClient {
+        val url = resolver.resolveUrl(parseResult)
+        return factory.create(url)
+    }
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/AppendFactCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/AppendFactCommand.kt
@@ -1,0 +1,58 @@
+package io.factstore.cli.command
+
+import io.factstore.cli.client.*
+import jakarta.inject.Inject
+import picocli.CommandLine.*
+import java.util.*
+import java.util.concurrent.Callable
+import kotlin.text.Charsets.UTF_8
+
+@Command(
+    name = "append",
+    description = ["Append a fact to a store"]
+)
+class AppendFactCommand : Callable<Int> {
+
+    @Inject
+    lateinit var client: FactStoreClient
+
+    @Parameters(index = "0")
+    lateinit var storeName: String
+
+    @Parameters(index = "1")
+    lateinit var type: String
+
+    @Parameters(index = "2", arity = "0..1")
+    var payload: String? = null
+
+    override fun call(): Int {
+        // If payload is null, try to read from STDIN
+        val rawData = payload ?: System.`in`.bufferedReader().readText()
+
+        if (rawData.isBlank()) {
+            System.err.println("❌ Error: No payload provided. Provide an argument or pipe data via STDIN.")
+            return ExitCode.SOFTWARE
+        }
+
+        val request = AppendHttpRequest(
+            facts = listOf(
+                FactHttp(
+                    type = type,
+                    subjectRef = SubjectRefHttp(type = "default", id = "default"), // To check...
+                    payload = FactPayloadHttp(data = rawData.toByteArray(UTF_8)),
+                )
+            ),
+            idempotencyKey = UUID.randomUUID()
+        )
+
+        try {
+            client.appendFact(storeName, request)
+            println("✅ Fact appended successfully.")
+            return ExitCode.OK
+        } catch (e: Exception) {
+            System.err.println("❌ Failed to append: ${e.message}")
+            return ExitCode.SOFTWARE
+        }
+    }
+
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/CreateStoreCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/CreateStoreCommand.kt
@@ -1,0 +1,31 @@
+package io.factstore.cli.command
+
+import io.factstore.cli.client.CreateStoreRequest
+import io.factstore.cli.client.FactStoreClient
+import jakarta.inject.Inject
+import kotlinx.coroutines.runBlocking
+import picocli.CommandLine.*
+import java.util.concurrent.Callable
+
+@Command(
+    name = "create",
+    description = ["Create a new logical store"]
+)
+class CreateStoreCommand : Callable<Int> {
+
+    @Inject
+    lateinit var client: FactStoreClient
+
+    @Parameters(
+        index = "0",
+        arity = "1",
+        description = ["The unique name of the store"]
+    )
+    lateinit var storeName: String
+
+    override fun call(): Int = runBlocking {
+        client.createStore(CreateStoreRequest(storeName))
+        println("✅ Store '$storeName' created successfully.")
+        ExitCode.OK
+    }
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/FactCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/FactCommand.kt
@@ -1,0 +1,14 @@
+package io.factstore.cli.command
+
+import picocli.CommandLine.Command
+
+@Command(
+    name = "fact",
+    aliases = [ "facts" ],
+    description = ["Operations around facts"],
+    subcommands = [
+        AppendFactCommand::class,
+        StreamFactsCommand::class,
+    ]
+)
+class FactCommand

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/FactStoreCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/FactStoreCommand.kt
@@ -1,0 +1,39 @@
+package io.factstore.cli.command
+
+import io.quarkus.picocli.runtime.annotations.TopCommand
+import kotlinx.coroutines.Runnable
+import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Option
+import picocli.CommandLine.ScopeType.INHERIT
+import picocli.CommandLine.Spec
+
+@TopCommand
+@Command(
+    name = "factstore",
+    mixinStandardHelpOptions = true,
+    version = ["0.1.0"],
+    description = ["FactStore Command Line Interface"],
+    subcommands = [
+        StoreCommand::class,
+        FactCommand::class,
+    ]
+)
+class FactStoreCommand : Runnable {
+
+    @Option(
+        names = ["--url"],
+        scope = INHERIT,
+        description = ["Server URL"]
+    )
+    var url: String? = null
+
+    @Spec
+    lateinit var spec: CommandSpec
+
+    override fun run() {
+        // print help menu
+        spec.commandLine().usage(System.err)
+    }
+
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/ListStoresCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/ListStoresCommand.kt
@@ -1,0 +1,44 @@
+package io.factstore.cli.command
+
+import io.factstore.cli.client.FactStoreClient
+import io.factstore.cli.client.StoreMetadata
+import jakarta.inject.Inject
+import kotlinx.coroutines.runBlocking
+import picocli.CommandLine.Command
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Command(
+    name = "list",
+    description = ["List all available logical stores"]
+)
+class ListStoresCommand : Runnable {
+
+    @Inject
+    lateinit var client: FactStoreClient
+
+    override fun run() = runBlocking {
+        val metadata = client.listStores()
+
+        if (metadata.isEmpty()) {
+            println("No stores found.")
+        } else {
+            metadata.print()
+        }
+    }
+
+    private fun List<StoreMetadata>.print() {
+        // Table Header
+        println("%-25s %-25s %-36s".format("NAME", "CREATED AT", "STORE ID"))
+        println("-".repeat(90))
+
+        // Table Rows
+        forEach { store ->
+            println("%-25s %-25s %-36s".format(
+                store.name,
+                LocalDateTime.ofInstant(store.createdAt, ZoneOffset.systemDefault()),
+                store.id
+            ))
+        }
+    }
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/StoreCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/StoreCommand.kt
@@ -1,0 +1,14 @@
+package io.factstore.cli.command
+
+import picocli.CommandLine.Command
+
+@Command(
+    name = "store",
+    aliases = [ "stores" ],
+    description = ["Manage stores"],
+    subcommands = [
+        CreateStoreCommand::class,
+        ListStoresCommand::class,
+    ]
+)
+class StoreCommand

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/StreamFactsCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/StreamFactsCommand.kt
@@ -1,0 +1,88 @@
+package io.factstore.cli.command
+
+import io.factstore.cli.client.FactHttp
+import io.factstore.cli.client.FactStoreClient
+import io.smallrye.mutiny.coroutines.asFlow
+import io.vertx.core.http.HttpClosedException
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.runBlocking
+import picocli.CommandLine.*
+import java.time.temporal.ChronoUnit.SECONDS
+import java.util.*
+import java.util.concurrent.Callable
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.text.Charsets.UTF_8
+
+@Command(
+    name = "stream",
+    description = ["Stream facts from a store in real-time (similar to tail -f)"]
+)
+class StreamFactsCommand : Callable<Int> {
+
+    @Inject
+    lateinit var client: FactStoreClient
+
+    @Parameters(
+        index = "0",
+        arity = "1",
+        description = ["The name of the store to stream from"]
+    )
+    lateinit var storeName: String
+
+    @ArgGroup(
+        exclusive = true,
+        heading = "Start position options:%n"
+    )
+    var startPosition = StartPosition()
+
+    class StartPosition {
+
+        @Option(
+            names = ["--from"],
+            description = ["Start from: 'beginning' or 'end'"],
+            showDefaultValue = Help.Visibility.ALWAYS,
+            defaultValue = "end"
+        )
+        var from: FromOption? = null
+
+        @Option(
+            names = ["--after"],
+            description = ["Start after a specific Fact UUID"]
+        )
+        var after: UUID? = null
+
+    }
+
+    enum class FromOption { beginning, end }
+
+    override fun call(): Int = runBlocking {
+        val fromValue = startPosition.from?.name
+        val afterValue = startPosition.after
+
+        client.streamFacts(storeName, fromValue, afterValue)
+            .asFlow()
+            .catch { cause -> cause.handleStreamTermination() }
+            .collect { fact -> fact.print() }
+
+        ExitCode.OK
+    }
+
+    private fun Throwable.handleStreamTermination() {
+        val underlying = (this as? CancellationException)?.cause ?: this
+        when (underlying) {
+            is HttpClosedException -> return  // normal termination (user Ctrl+C or server closed stream)
+            else -> throw underlying
+        }
+    }
+
+    private fun FactHttp.print() {
+        println(
+            "[%s] %-15s | %s".format(
+                appendedAt?.truncatedTo(SECONDS),
+                type,
+                String(payload.data, charset = UTF_8)
+            )
+        )
+    }
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/config/ConfigService.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/config/ConfigService.kt
@@ -1,0 +1,20 @@
+package io.factstore.cli.config
+
+import jakarta.enterprise.context.ApplicationScoped
+import java.io.File
+import java.util.Properties
+
+@ApplicationScoped
+class ConfigService {
+
+    private val configDir = File(System.getProperty("user.home"), ".factstore")
+    private val configFile = File(configDir, "config")
+
+    fun getUrl(): String? {
+        if (!configFile.exists()) return null
+        val props = Properties()
+        configFile.inputStream().use { props.load(it) }
+        return props.getProperty("url")
+    }
+
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/config/FactStoreConfigResolver.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/config/FactStoreConfigResolver.kt
@@ -1,0 +1,27 @@
+package io.factstore.cli.config
+
+import jakarta.enterprise.context.ApplicationScoped
+import picocli.CommandLine
+import java.net.URI
+
+@ApplicationScoped
+class FactStoreConfigResolver(
+    private val configService: ConfigService,
+) {
+
+    fun resolveUrl(parseResult: CommandLine.ParseResult): URI {
+        val flagUrl =
+            parseResult.asCommandLineList()
+                .reversed()
+                .firstNotNullOfOrNull { it.parseResult.matchedOption("--url") }
+                ?.getValue<String>()
+
+        val resolved = flagUrl
+            ?: System.getenv("FACTSTORE_URL")
+            ?: configService.getUrl()
+            ?: "http://localhost:8080/api"
+
+        return URI.create(resolved)
+    }
+
+}

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/exception/FactStoreExecutionExceptionHandler.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/exception/FactStoreExecutionExceptionHandler.kt
@@ -1,0 +1,39 @@
+package io.factstore.cli.exception
+
+import io.factstore.cli.client.FactStoreApiException
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.ProcessingException
+import picocli.CommandLine
+import picocli.CommandLine.ExitCode
+import java.lang.Exception
+import java.net.UnknownHostException
+
+@ApplicationScoped
+class FactStoreExecutionExceptionHandler : CommandLine.IExecutionExceptionHandler {
+
+    override fun handleExecutionException(
+        exception: Exception,
+        commandLine: CommandLine,
+        fullParseResult: CommandLine.ParseResult
+    ): Int {
+        val message = exception.toCliMessage()
+        commandLine.err.println(message)
+        return ExitCode.SOFTWARE
+    }
+
+}
+
+private fun Exception.toCliMessage(): String = when (this) {
+    is FactStoreApiException -> toCliMessage()
+    is ProcessingException -> "❌ Network Error: ${this.cause?.message ?: this.message}"
+    is UnknownHostException -> "❌ Could not resolve host: ${this.message}"
+    else -> "❌ Unexpected Error: ${this.message}"
+}
+
+private fun FactStoreApiException.toCliMessage(): String {
+    return if (apiError != null) {
+        "Error from server (${apiError.reason}): ${apiError.message}"
+    } else {
+        "❌ Server Error: HTTP $httpStatus"
+    }
+}

--- a/factstore-cli/src/main/resources/application.yaml
+++ b/factstore-cli/src/main/resources/application.yaml
@@ -1,0 +1,23 @@
+quarkus:
+  banner:
+    enabled: false
+  log:
+    level: WARN
+    category:
+      "io.factstore.cli":
+        level: INFO
+    console:
+      format: "%m%n"
+  package:
+    jar:
+      enabled: true
+
+"%dev":
+  quarkus:
+    log:
+      level: INFO
+      category:
+        "io.factstore.cli":
+          level: DEBUG
+      console:
+        format: "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n"


### PR DESCRIPTION
Initial version of FactStore CLI.

Includes the following features:

- create stores via: `factstore store create mystore`
- list stores via `factstore store list`
- append facts via `factstore fact append ...`
- stream facts via `factstore fact stream mystore --from=beginning`
