### PR TITLE
#152 Replace SubjectRef with plain Subject

### DIFF
--- a/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClient.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/client/FactStoreClient.kt
@@ -63,11 +63,10 @@ interface FactStoreClient {
 
     @GET
     @Produces(APPLICATION_JSON)
-    @Path("/stores/{store}/subjects/{subjectType}/{subjectId}/facts")
+    @Path("/stores/{store}/subjects/{subject}/facts")
     fun findFactsBySubject(
         @PathParam("store") storeName: String,
-        @PathParam("subjectType") subjectType: String,
-        @PathParam("subjectId") subjectId: String,
+        @PathParam("subject") subject: String,
     ): List<FactHttp>
 
     @GET
@@ -92,7 +91,7 @@ data class StoreMetadata(
 data class FactHttp(
     val id: UUID? = null,
     val type: String,
-    val subjectRef: SubjectRefHttp,
+    val subject: String,
     val appendedAt: Instant? = null,
     val payload: FactPayloadHttp,
     val metadata: Map<String, String> = emptyMap(),
@@ -101,11 +100,6 @@ data class FactHttp(
 
 data class FactPayloadHttp(
     val data: ByteArray,
-)
-
-data class SubjectRefHttp(
-    val type: String,
-    val id: String
 )
 
 data class AppendHttpRequest(

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/AppendFactCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/AppendFactCommand.kt
@@ -38,7 +38,7 @@ class AppendFactCommand : Callable<Int> {
             facts = listOf(
                 FactHttp(
                     type = type,
-                    subjectRef = SubjectRefHttp(type = "default", id = "default"), // To check...
+                    subject = "default",
                     payload = FactPayloadHttp(data = rawData.toByteArray(UTF_8)),
                 )
             ),

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/FindFactsCommand.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/FindFactsCommand.kt
@@ -3,16 +3,11 @@ package io.factstore.cli.command
 import io.factstore.cli.client.FactStoreClient
 import io.factstore.cli.converter.FlexibleInstantConverter
 import jakarta.inject.Inject
-import picocli.CommandLine
-import picocli.CommandLine.ArgGroup
-import picocli.CommandLine.Command
-import picocli.CommandLine.Model.CommandSpec
-import picocli.CommandLine.Option
-import picocli.CommandLine.Spec
+import picocli.CommandLine.*
 import java.time.Instant
 import java.util.concurrent.Callable
 
-@Command(name = "facts",)
+@Command(name = "facts")
 class FindFactsCommand : Callable<Int> {
 
     @Inject
@@ -33,7 +28,7 @@ class FindFactsCommand : Callable<Int> {
 
     @Option(
         names = ["--limit"],
-        description = ["Maximum number of facts to return (default: \${DEFAULT-VALUE})"],
+        description = [$$"Maximum number of facts to return (default: ${DEFAULT-VALUE})"],
         defaultValue = "100",
     )
     var limit: Int = 100
@@ -44,23 +39,12 @@ class FindFactsCommand : Callable<Int> {
     )
     var reversed: Boolean = false
 
-    @Spec
-    lateinit var spec: CommandSpec
-
     override fun call(): Int {
         val subject = filter?.subject
         val timeRange = filter?.timeRange
 
         val facts = when {
-            subject != null -> {
-                val parts = subject.split("/", limit = 2)
-                val subjectType = parts[0]
-                val subjectId = parts.getOrNull(1) ?: throw CommandLine.ParameterException(
-                    spec.commandLine(),
-                    "Subject must be in type/id format (e.g. order/123), got: '$subject'"
-                )
-                client.findFactsBySubject(storeName, subjectType, subjectId)
-            }
+            subject != null -> client.findFactsBySubject(storeName, subject)
             timeRange != null -> client.findFactsInTimeRange(
                 storeName = storeName,
                 from = timeRange.since,
@@ -78,10 +62,8 @@ class FindFactsCommand : Callable<Int> {
         }
 
         printTable(facts)
-        return CommandLine.ExitCode.OK
+        return ExitCode.OK
     }
-
-
 
 }
 

--- a/factstore-cli/src/main/kotlin/io/factstore/cli/command/extensions.kt
+++ b/factstore-cli/src/main/kotlin/io/factstore/cli/command/extensions.kt
@@ -22,7 +22,7 @@ fun printTable(facts: List<FactHttp>) {
 
     val idWidth       = 36
     val typeWidth     = facts.maxOf { it.type.length }.coerceAtLeast(4)
-    val subjectWidth  = facts.maxOf { (it.subjectRef.type + it.subjectRef.id).length }.coerceAtLeast(7)
+    val subjectWidth  = facts.maxOf { it.subject.length }.coerceAtLeast(7)
     val timeWidth     = 20
     val payloadWidth  = 40
 
@@ -43,7 +43,7 @@ fun printTable(facts: List<FactHttp>) {
             "%-${idWidth}s  %-${typeWidth}s  %-${subjectWidth}s  %-${timeWidth}s  %-${payloadWidth}s".format(
                 fact.id,
                 fact.type,
-                fact.subjectRef.type + ":" + fact.subjectRef.id,
+                fact.subject,
                 fact.appendedAt?.truncatedTo(SECONDS) ?: "",
                 payload,
             )

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactAppender.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactAppender.kt
@@ -108,7 +108,7 @@ class FdbFactAppender(
 
     context(tr: Transaction, storeId: StoreId)
     private fun AppendCondition.ExpectedLastFact.isSatisfied(): CompletableFuture<Boolean> {
-        val actualLastFactId = subjectRef.getLastFactId()
+        val actualLastFactId = subject.getLastFactId()
         val isConditionSatisfied = actualLastFactId == expectedLastFactId
         return CompletableFuture.completedFuture(isConditionSatisfied)
     }
@@ -120,7 +120,7 @@ class FdbFactAppender(
     }
 
     context(tr: Transaction, storeId: StoreId)
-    private fun SubjectRef.getLastFactId(): FactId? {
+    private fun Subject.getLastFactId(): FactId? {
         val subjectRange = store.context.subjectIndexSubspace.range(storeId, this)
         val latestFactKeyValue = tr.getRange(subjectRange, LIMIT_ONE, REVERSED).firstOrNull()
         return latestFactKeyValue?.let {

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactFinder.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactFinder.kt
@@ -86,14 +86,14 @@ class FdbFactFinder(private val fdbFactStore: FdbFactStore) : FactFinder {
         }.await()
     }
 
-    override suspend fun findBySubject(storeName: StoreName, subjectRef: SubjectRef): FindBySubjectResult {
+    override suspend fun findBySubject(storeName: StoreName, subject: Subject): FindBySubjectResult {
         return db.readAsync { tr ->
             with(tr) {
                 fdbFactStore.context.lookUpStoreIdByName(storeName).thenCompose { storeId ->
                     if (storeId == null) {
                         CompletableFuture.completedFuture(FindBySubjectResult.StoreNotFound(storeName))
                     } else {
-                        val subjectRange = subjectIndexSubspace.range(storeId, subjectRef)
+                        val subjectRange = subjectIndexSubspace.range(storeId, subject)
                         tr.getRange(subjectRange).asList().thenCompose { kvs ->
                             val factFutures: List<CompletableFuture<FdbFact?>> = kvs.map { kv ->
                                 val factPosition = subjectIndexSubspace.unpackPosition(kv.key)

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStore.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStore.kt
@@ -84,7 +84,7 @@ data class FdbFactStore(
         context.headSubspace.save(storeId, incompleteVersionstamp)
         context.eventTypeIndexSubspace.save(storeId, id, type, incompleteVersionstamp)
         context.createdAtIndexSubspace.save(storeId, id, appendedAt, incompleteVersionstamp)
-        context.subjectIndexSubspace.save(storeId, id, subjectRef, incompleteVersionstamp)
+        context.subjectIndexSubspace.save(storeId, id, subject, incompleteVersionstamp)
         context.metadataIndexSubspace.save(storeId, id, metadata, incompleteVersionstamp)
         context.tagsIndexSubspace.save(storeId, id, tags, incompleteVersionstamp)
         context.tagsTypeIndexSubspace.save(storeId, id, type, tags, incompleteVersionstamp)
@@ -149,8 +149,7 @@ fun Tuple.getLastAsFactPosition(): FactPosition = getVersionstamp(size() - 1)
 fun Fact.toSerializableFdbFact() = SerializableFdbFact(
     id = id.uuid,
     type = type.value,
-    subjectType = subjectRef.type,
-    subjectId = subjectRef.id,
+    subject = subject.value,
     timeEpochSeconds = appendedAt.epochSecond,
     timeNanos = appendedAt.nano,
     metadata = metadata,
@@ -174,10 +173,7 @@ fun SerializableFdbFact.toFact() = Fact(
         format = payload.format?.toPayloadFormat(),
         schema = payload.format?.toPayloadSchemaRef()
     ),
-    subjectRef = SubjectRef(
-        type = subjectType,
-        id = subjectId
-    ),
+    subject = Subject(subject),
     appendedAt = Instant.ofEpochSecond(timeEpochSeconds, timeNanos.toLong()),
     metadata = metadata,
     tags = tags.entries.associate { it.key.toTagKey() to it.value.toTagValue() }

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStoreContext.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/FdbFactStoreContext.kt
@@ -14,7 +14,7 @@ import io.factstore.core.StoreId
 import io.factstore.core.StoreName
 import io.factstore.core.FactType
 import io.factstore.core.IdempotencyKey
-import io.factstore.core.SubjectRef
+import io.factstore.core.Subject
 import io.factstore.core.TagKey
 import io.factstore.core.TagValue
 import kotlinx.serialization.decodeFromByteArray
@@ -255,12 +255,12 @@ value class CreatedAtIndexSubspace(val subspace: Subspace) {
 @JvmInline
 value class SubjectIndexSubspace(val subspace: Subspace) {
 
-    fun range(storeId: StoreId, subjectRef: SubjectRef): Range =
-        subspace.range(Tuple.from(storeId.uuid, subjectRef.type, subjectRef.id))
+    fun range(storeId: StoreId, subject: Subject): Range =
+        subspace.range(Tuple.from(storeId.uuid, subject.value))
 
     context(tr: Transaction)
-    fun save(storeId: StoreId, factId: FactId, subjectRef: SubjectRef, incompleteVersionstamp: Versionstamp) {
-        val keyTuple = Tuple.from(storeId.uuid, subjectRef.type, subjectRef.id, incompleteVersionstamp)
+    fun save(storeId: StoreId, factId: FactId, subject: Subject, incompleteVersionstamp: Versionstamp) {
+        val keyTuple = Tuple.from(storeId.uuid, subject.value, incompleteVersionstamp)
         val keyBytes = subspace.packWithVersionstamp(keyTuple)
         val factIdTuple = Tuple.from(factId.uuid).pack()
         tr.mutate(SET_VERSIONSTAMPED_KEY, keyBytes, factIdTuple)

--- a/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/SerializableFdbFact.kt
+++ b/factstore-foundationdb/src/main/kotlin/io/factstore/foundationdb/SerializableFdbFact.kt
@@ -9,8 +9,7 @@ data class SerializableFdbFact(
     @Contextual
     val id: UUID,
     val type: String,
-    val subjectType: String,
-    val subjectId: String,
+    val subject: String,
     val timeEpochSeconds: Long,
     val timeNanos: Int,
     val metadata: Map<String, String> = emptyMap(),

--- a/factstore-memory/src/main/kotlin/io/factstore/memory/MemoryFactStore.kt
+++ b/factstore-memory/src/main/kotlin/io/factstore/memory/MemoryFactStore.kt
@@ -137,10 +137,10 @@ class MemoryFactStore : FactStore {
         FindInTimeRangeResult.Found(foundFacts)
     }
 
-    override suspend fun findBySubject(storeName: StoreName, subjectRef: SubjectRef): FindBySubjectResult = lock.withLock {
+    override suspend fun findBySubject(storeName: StoreName, subject: Subject): FindBySubjectResult = lock.withLock {
         val internalId = resolveId(storeName) ?: return FindBySubjectResult.StoreNotFound(storeName)
 
-        val foundFacts = facts[internalId]?.filter { it.subjectRef == subjectRef } ?: emptyList()
+        val foundFacts = facts[internalId]?.filter { it.subject == subject } ?: emptyList()
         FindBySubjectResult.Found(foundFacts)
     }
 
@@ -204,13 +204,13 @@ class MemoryFactStore : FactStore {
             AppendCondition.None -> true
             is AppendCondition.ExpectedLastFact -> {
                 val store = facts[storeId]?.toList() ?: return false
-                val lastFact = store.findLast { it.subjectRef == condition.subjectRef }
+                val lastFact = store.findLast { it.subject == condition.subject }
                 lastFact?.id == condition.expectedLastFactId
             }
             is AppendCondition.ExpectedMultiSubjectLastFact -> {
                 val store = facts[storeId]?.toList() ?: return false
-                condition.expectations.all { (subjectRef, expectedId) ->
-                    val lastFact = store.findLast { it.subjectRef == subjectRef }
+                condition.expectations.all { (subject, expectedId) ->
+                    val lastFact = store.findLast { it.subject == subject }
                     lastFact?.id == expectedId
                 }
             }

--- a/factstore-server/scripts/curl-samples/simple-append.sh
+++ b/factstore-server/scripts/curl-samples/simple-append.sh
@@ -6,10 +6,7 @@ curl -X 'POST' \
    "facts":[
       {
          "type":"UserCreated",
-         "subjectRef":{
-            "type":"user",
-            "id":"user-3"
-         },
+         "subject":"user-4",
          "payload":{
             "data":"SGVsbG8gd29ybGQ="
          },

--- a/factstore-server/scripts/k6/single_append_with_condition.js
+++ b/factstore-server/scripts/k6/single_append_with_condition.js
@@ -16,7 +16,7 @@ export let options = {
 };
 
 export default function() {
-    const url = 'http://localhost:8080/api/v1/stores/my-fact-store/facts';
+    const url = 'http://localhost:8080/api/v1/stores/test/facts';
 
     const userId = uuidv4();
 
@@ -37,10 +37,7 @@ export default function() {
         facts: [{
             id: uuidv4(),
             type: 'UserCreated',
-            subjectRef: {
-                type: 'user',
-                id: `user-${__VU}`,
-            },
+            subject: `user-${__VU}`,
             payload: {
                 // "Hello world" base64-encoded
                 data: 'SGVsbG8gd29ybGQ='

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/QueryResource.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/QueryResource.kt
@@ -38,14 +38,13 @@ class QueryResource(
 
     @GET
     @Produces(APPLICATION_JSON)
-    @Path("/subjects/{subjectType}/{subjectId}/facts")
+    @Path("/subjects/{subject}/facts")
     suspend fun findBySubject(
         @PathParam("storeName") storeName: String,
-        @PathParam("subjectType") subjectType: String,
-        @PathParam("subjectId") subjectId: String,
+        @PathParam("subject") subject: String,
     ): Response =
         store
-            .findBySubject(StoreName(storeName), SubjectRef(subjectType, subjectId))
+            .findBySubject(StoreName(storeName), Subject(subject))
             .toResponse()
 
     @GET

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/api.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/api.kt
@@ -39,12 +39,12 @@ sealed interface AppendConditionHttp {
     data object None : AppendConditionHttp
 
     data class ExpectedLastFact(
-        val subjectRef: SubjectRefHttp,
+        val subject: String,
         val expectedLastFactId: UUID?
     ) : AppendConditionHttp
 
     data class ExpectedMultiSubjectLastFact(
-        val expectations: Map<SubjectRefHttp, UUID?>
+        val expectations: Map<String, UUID?>
     ) : AppendConditionHttp
 
     data class TagQueryBased(
@@ -87,7 +87,7 @@ sealed interface TagQueryItemHttp {
 data class FactHttp(
     val id: UUID?,
     val type: String,
-    val subjectRef: SubjectRefHttp,
+    val subject: String,
     val appendedAt: Instant?,
     val payload: FactPayloadHttp,
     val metadata: Map<String, String> = emptyMap(),
@@ -96,11 +96,6 @@ data class FactHttp(
 
 data class FactPayloadHttp(
     val data: ByteArray,
-)
-
-data class SubjectRefHttp(
-    val type: String,
-    val id: String
 )
 
 data class CreateStoreHttpRequest(

--- a/factstore-server/src/main/kotlin/io/factstore/server/http/extensions.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/http/extensions.kt
@@ -9,7 +9,7 @@ import io.factstore.core.FactId
 import io.factstore.core.FactPayload
 import io.factstore.core.IdempotencyKey
 import io.factstore.core.StoreName
-import io.factstore.core.SubjectRef
+import io.factstore.core.Subject
 import io.factstore.core.TagOnlyQueryItem
 import io.factstore.core.TagQuery
 import io.factstore.core.TagQueryItem
@@ -43,14 +43,14 @@ fun AppendConditionHttp.toAppendCondition(): AppendCondition =
 
         is AppendConditionHttp.ExpectedLastFact ->
             AppendCondition.ExpectedLastFact(
-                subjectRef = subjectRef.toSubjectRef(),
+                subject = Subject(subject),
                 expectedLastFactId = expectedLastFactId?.toFactId()
             )
 
         is AppendConditionHttp.ExpectedMultiSubjectLastFact ->
             AppendCondition.ExpectedMultiSubjectLastFact(
                 expectations = expectations.mapKeys { (subject, _) ->
-                    subject.toSubjectRef()
+                    Subject(subject)
                 }.mapValues { (_, factId) ->
                     factId?.toFactId()
                 }
@@ -93,7 +93,7 @@ fun FactHttp.toFact() = Fact(
     id = id?.toFactId() ?: FactId.generate(),
     type = type.toFactType(),
     payload = payload.toPayload(),
-    subjectRef = subjectRef.toSubjectRef(),
+    subject = Subject(subject),
     appendedAt = appendedAt ?: Instant.now(),
     metadata = metadata,
     tags = tags.entries.associate { Pair(it.key.toTagKey(), it.value.toTagValue()) }
@@ -103,24 +103,14 @@ private fun FactPayloadHttp.toPayload(): FactPayload = FactPayload(
     data = data,
 )
 
-private fun SubjectRefHttp.toSubjectRef() = SubjectRef(
-    type = type,
-    id = id
-)
-
 fun Fact.toFactHttp() = FactHttp(
     id = id.uuid,
     type = type.value,
-    subjectRef = subjectRef.toSubjectRefHttp(),
+    subject = subject.value,
     appendedAt = appendedAt,
     payload = payload.toFactPayloadHttp(),
     metadata = metadata,
     tags = tags.entries.associate { Pair(it.key.value, it.value.value) }
-)
-
-fun SubjectRef.toSubjectRefHttp() = SubjectRefHttp(
-    type = type,
-    id = id
 )
 
 fun FactPayload.toFactPayloadHttp() = FactPayloadHttp(

--- a/factstore-specification/src/main/kotlin/io/factstore/core/AppendRequest.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/AppendRequest.kt
@@ -67,12 +67,12 @@ sealed interface AppendCondition {
      * Requires that the last fact associated with the given subject matches
      * the expected fact identifier.
      *
-     * @property subjectRef the subject whose last fact is checked
+     * @property subject the subject whose last fact is checked
      * @property expectedLastFactId the expected identifier of the last fact,
      *         or `null` if no fact is expected to exist
      */
     data class ExpectedLastFact(
-        val subjectRef: SubjectRef,
+        val subject: Subject,
         val expectedLastFactId: FactId?
     ) : AppendCondition
 
@@ -84,7 +84,7 @@ sealed interface AppendCondition {
      *         last fact identifiers
      */
     data class ExpectedMultiSubjectLastFact(
-        val expectations: Map<SubjectRef, FactId?>
+        val expectations: Map<Subject, FactId?>
     ) : AppendCondition
 
     /**

--- a/factstore-specification/src/main/kotlin/io/factstore/core/Fact.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/Fact.kt
@@ -14,7 +14,7 @@ import java.util.*
  * - **Identity** ([id]) for uniqueness and idempotency
  * - **Classification** ([type]) describing what kind of fact occurred
  * - **Payload** ([payload]) containing the event data and its transport metadata
- * - **Subject association** ([subjectRef]) defining the entity or context
+ * - **Subject association** ([subject]) defining the entity or context
  *   the fact belongs to
  * - **Temporal information** ([appendedAt]) indicating when the fact occurred
  * - **Metadata** ([metadata]) for auxiliary, non-indexed information
@@ -27,7 +27,7 @@ import java.util.*
  * @property id the globally unique identifier of the fact
  * @property type the logical type of the fact
  * @property payload the serialized fact payload
- * @property subjectRef the subject the fact is associated with
+ * @property subject the subject the fact is associated with
  * @property appendedAt the time the fact was appended
  * @property metadata optional metadata associated with the fact
  * @property tags optional tags used for querying and classification
@@ -38,7 +38,7 @@ data class Fact(
     val id: FactId,
     val type: FactType,
     val payload: FactPayload,
-    val subjectRef: SubjectRef,
+    val subject: Subject,
     val appendedAt: Instant,
     val metadata: Map<String, String> = emptyMap(),
     val tags: Map<TagKey, TagValue> = emptyMap(),
@@ -129,21 +129,27 @@ value class PayloadSchemaRef(val value: String) {
     }
 }
 
+
 /**
- * Identifies the subject a fact belongs to.
+ * Identifies the logical entity, boundary, or concept a fact belongs to.
+ * Subjects are a modeling concept to group related facts together.
  *
- * Subjects define logical groupings of facts and are commonly used to model
- * entities, aggregates, or other consistency boundaries.
+ * All facts with the same subject are treated as part of the same history.
+ * FactStore treats the subject as a flat, opaque string, allowing you to use
+ * any naming convention that fits your domain (e.g., UUIDs, custom identifiers,
+ * or hierarchical paths).
  *
- * @property type the subject type
- * @property id the unique identifier of the subject within its type
- *
+ * @property value The string representation of the subject.
+ *                 Must not be blank and must not contain leading or trailing whitespace.
  * @author Domenic Cassisi
  */
-data class SubjectRef(
-    val type: String,
-    val id: String
-)
+@JvmInline
+value class Subject(val value: String) {
+    init {
+        require(value.isNotBlank()) { "Subject must not be blank" }
+        require(value == value.trim()) { "Subject must not contain leading or trailing whitespaces" }
+    }
+}
 
 /**
  * Globally unique identifier of a fact.

--- a/factstore-specification/src/main/kotlin/io/factstore/core/FactFinder.kt
+++ b/factstore-specification/src/main/kotlin/io/factstore/core/FactFinder.kt
@@ -56,11 +56,11 @@ interface FactFinder {
      * Retrieves the complete history of facts associated with a specific subject.
      *
      * @param storeName the logical name of the store.
-     * @param subjectRef the subject reference
+     * @param subject the subject for which to retrieve the fact history.
      * @return a [FindBySubjectResult.Found] containing the stream of facts for this subject,
      *         or [FindBySubjectResult.StoreNotFound] if the store is missing.
      */
-    suspend fun findBySubject(storeName: StoreName, subjectRef: SubjectRef): FindBySubjectResult
+    suspend fun findBySubject(storeName: StoreName, subject: Subject): FindBySubjectResult
 
     /**
      * Finds facts that match at least one of the provided tags (OR logic).

--- a/factstore-specification/src/test/kotlin/io/factstore/core/AppendRequestTest.kt
+++ b/factstore-specification/src/test/kotlin/io/factstore/core/AppendRequestTest.kt
@@ -11,10 +11,7 @@ class AppendRequestTest {
 
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "TEST_TYPE",
-                id = "TEST_ID",
-            ),
+            subject = Subject("TEST_SUBJECT"),
             type = FactType("TEST_FACT_TYPE"),
             payload = """DATA""".toFactPayload(),
             appendedAt = Instant.now(),

--- a/factstore-testing/src/main/kotlin/io/factstore/testing/AbstractFactStoreTest.kt
+++ b/factstore-testing/src/main/kotlin/io/factstore/testing/AbstractFactStoreTest.kt
@@ -15,6 +15,10 @@ import java.time.Instant
 import java.util.UUID
 import kotlin.system.measureTimeMillis
 
+private const val ALICE_SUBJECT_VALUE = "USER:ALICE"
+private const val BOB_SUBJECT_VALUE = "USER:BOB"
+private const val CHARLIE_SUBJECT_VALUE = "USER:CHARLIE"
+
 abstract class AbstractFactStoreTest {
 
     private var testStore = StoreName("default-test-store")
@@ -85,10 +89,7 @@ abstract class AbstractFactStoreTest {
 
         val fact = Fact(
             id = id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_ONBOARDED".toFactType(),
             payload = payload,
             appendedAt = createdAt
@@ -138,10 +139,7 @@ abstract class AbstractFactStoreTest {
 
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = now.minusSeconds(60) // 1 minute ago
@@ -149,10 +147,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_UPDATED".toFactType(),
             payload = """{ "username": "Alice", "status": "active" }""".toFactPayload(),
             appendedAt = now
@@ -160,10 +155,7 @@ abstract class AbstractFactStoreTest {
 
         val fact3 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_DELETED".toFactType(),
             payload = bobPayload,
             appendedAt = now.plusSeconds(60) // 1 minute in the future
@@ -206,10 +198,7 @@ abstract class AbstractFactStoreTest {
         val fact1Id = FactId.generate()
         val fact1 = Fact(
             id = fact1Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now()
@@ -221,10 +210,7 @@ abstract class AbstractFactStoreTest {
             facts = listOf(fact1),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.ExpectedLastFact(
-                subjectRef = SubjectRef(
-                    type = "USER",
-                    id = "ALICE"
-                ),
+                subject = Subject(ALICE_SUBJECT_VALUE),
                 expectedLastFactId = null
             )
         )
@@ -238,10 +224,7 @@ abstract class AbstractFactStoreTest {
         val fact2Id = FactId.generate()
         val fact2 = Fact(
             id = fact2Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_LOCKED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now()
@@ -252,10 +235,7 @@ abstract class AbstractFactStoreTest {
             facts = listOf(fact2),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.ExpectedLastFact(
-                subjectRef = SubjectRef(
-                    type = "USER",
-                    id = "ALICE"
-                ),
+                subject = Subject(ALICE_SUBJECT_VALUE),
                 expectedLastFactId = fact1Id
             )
         )
@@ -272,10 +252,7 @@ abstract class AbstractFactStoreTest {
             facts = listOf(fact3),
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.ExpectedLastFact(
-                subjectRef = SubjectRef(
-                    type = "USER",
-                    id = "ALICE"
-                ),
+                subject = Subject(ALICE_SUBJECT_VALUE),
                 expectedLastFactId = fact1Id // <-- this will cause the violation
             )
         )
@@ -294,10 +271,7 @@ abstract class AbstractFactStoreTest {
 
         val fact1 = Fact(
             id = fact1Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now()
@@ -305,10 +279,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = fact2Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now()
@@ -316,10 +287,7 @@ abstract class AbstractFactStoreTest {
 
         val fact3 = Fact(
             id = fact3Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_LOCKED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now()
@@ -331,8 +299,8 @@ abstract class AbstractFactStoreTest {
             idempotencyKey = IdempotencyKey(),
             condition = AppendCondition.ExpectedMultiSubjectLastFact(
                 expectations = mapOf(
-                    SubjectRef("USER", "ALICE") to null,
-                    SubjectRef("USER", "BOB") to null,
+                    Subject(ALICE_SUBJECT_VALUE) to null,
+                    Subject(BOB_SUBJECT_VALUE) to null,
                 )
             )
         )
@@ -352,10 +320,7 @@ abstract class AbstractFactStoreTest {
 
         val fact1 = Fact(
             id = fact1Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now()
@@ -363,10 +328,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = fact2Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now()
@@ -374,10 +336,7 @@ abstract class AbstractFactStoreTest {
 
         val fact3 = Fact(
             id = fact3Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_LOCKED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now()
@@ -387,28 +346,28 @@ abstract class AbstractFactStoreTest {
 
         store.append(testStore, factsToAppend)
 
-        val aliceResult = store.findBySubject(testStore, SubjectRef("USER", "ALICE"))
+        val aliceResult = store.findBySubject(testStore, Subject(ALICE_SUBJECT_VALUE))
         assertThat(aliceResult).isInstanceOf(FindBySubjectResult.Found::class.java)
         assertThat((aliceResult as FindBySubjectResult.Found).facts)
             .containsExactly(fact1, fact3)
 
-        val bobResult = store.findBySubject(testStore, SubjectRef("USER", "BOB"))
+        val bobResult = store.findBySubject(testStore, Subject(BOB_SUBJECT_VALUE))
         assertThat(bobResult).isInstanceOf(FindBySubjectResult.Found::class.java)
         assertThat((bobResult as FindBySubjectResult.Found).facts)
             .containsExactly(fact2)
 
-        val peterResult = store.findBySubject(testStore, SubjectRef("USER", "PETER"))
+        val peterResult = store.findBySubject(testStore, Subject("USER:PETER"))
         assertThat(peterResult).isInstanceOf(FindBySubjectResult.Found::class.java)
         assertThat((peterResult as FindBySubjectResult.Found).facts).isEmpty()
 
-        val unknownResult = store.findBySubject(testStore, SubjectRef("UNKNOWN", "UNKNOWN"))
+        val unknownResult = store.findBySubject(testStore, Subject("UNKNOWN:UNKNOWN"))
         assertThat(unknownResult).isInstanceOf(FindBySubjectResult.Found::class.java)
         assertThat((unknownResult as FindBySubjectResult.Found).facts).isEmpty()
     }
 
     @Test
     fun findBySubjectForNonExistingFactstore(): Unit = runBlocking {
-        val result = store.findBySubject(nonExistingStore, SubjectRef("SOME_TYPE", "SOME_ID"))
+        val result = store.findBySubject(nonExistingStore, Subject("SOME_TYPE:SOME_ID"))
         assertThat(result).isInstanceOf(FindBySubjectResult.StoreNotFound::class.java)
     }
 
@@ -420,10 +379,7 @@ abstract class AbstractFactStoreTest {
 
         val fact1 = Fact(
             id = fact1Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -432,10 +388,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = fact2Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now()
@@ -455,10 +408,7 @@ abstract class AbstractFactStoreTest {
     fun appendEventsWithTagsAndFindThem(): Unit = runBlocking {
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -468,10 +418,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now(),
@@ -481,10 +428,7 @@ abstract class AbstractFactStoreTest {
 
         val fact3 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "CHARLIE",
-            ),
+            subject = Subject(CHARLIE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = charliePayload,
             appendedAt = Instant.now(),
@@ -665,7 +609,7 @@ abstract class AbstractFactStoreTest {
     ): Fact =
         Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = subjectId),
+            subject = Subject("USER:$subjectId"),
             type = "USER_CREATED".toFactType(),
             payload = """{ "username": "$username" }""".toFactPayload(),
             appendedAt = Instant.now(),
@@ -689,10 +633,7 @@ abstract class AbstractFactStoreTest {
 
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -702,10 +643,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now(),
@@ -715,10 +653,7 @@ abstract class AbstractFactStoreTest {
 
         val fact3 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "CHARLIE",
-            ),
+            subject = Subject(CHARLIE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = charliePayload,
             appendedAt = Instant.now(),
@@ -862,7 +797,7 @@ abstract class AbstractFactStoreTest {
         // Create facts with different types
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "ALICE"),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -872,7 +807,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "BOB"),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_UPDATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now(),
@@ -882,7 +817,7 @@ abstract class AbstractFactStoreTest {
 
         val fact3 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
+            subject = Subject(CHARLIE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = charliePayload,
             appendedAt = Instant.now(),
@@ -914,7 +849,7 @@ abstract class AbstractFactStoreTest {
         // Create facts with different types and tags
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "ALICE"),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -924,7 +859,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "BOB"),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_UPDATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now(),
@@ -934,7 +869,7 @@ abstract class AbstractFactStoreTest {
 
         val fact3 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
+            subject = Subject(CHARLIE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = charliePayload,
             appendedAt = Instant.now(),
@@ -972,7 +907,7 @@ abstract class AbstractFactStoreTest {
         // Create facts with different types and tags
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "ALICE"),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -982,7 +917,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "BOB"),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_UPDATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now(),
@@ -992,7 +927,7 @@ abstract class AbstractFactStoreTest {
 
         val fact3 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "CHARLIE"),
+            subject = Subject(CHARLIE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = charliePayload,
             appendedAt = Instant.now(),
@@ -1029,7 +964,7 @@ abstract class AbstractFactStoreTest {
         // Create facts with different types and tags
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(type = "USER", id = "ALICE"),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -1065,10 +1000,7 @@ abstract class AbstractFactStoreTest {
 
             Fact(
                 id = FactId.generate(),
-                subjectRef = SubjectRef(
-                    type = "USER",
-                    id = "user-$index"
-                ),
+                subject = Subject("USER:user-$index"),
                 type = "USER_CREATED".toFactType(),
                 payload = """{ "username": "user$index" }""".toFactPayload(),
                 appendedAt = Instant.now(),
@@ -1090,10 +1022,7 @@ abstract class AbstractFactStoreTest {
             testStore,
             Fact(
                 id = FactId.generate(),
-                subjectRef = SubjectRef(
-                    type = "USER",
-                    id = "user-${FactId.generate()}"
-                ),
+                subject = Subject("USER:user-${FactId.generate()}"),
                 type = "USER_CREATED".toFactType(),
                 payload = """{ "username": "user" }""".toFactPayload(),
                 appendedAt = Instant.now(),
@@ -1180,10 +1109,7 @@ abstract class AbstractFactStoreTest {
         val fact1Id = FactId.generate()
         val fact1 = Fact(
             id = fact1Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -1218,10 +1144,7 @@ abstract class AbstractFactStoreTest {
         val fact2Id = FactId.generate()
         val fact2 = Fact(
             id = fact2Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_LOCKED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -1261,10 +1184,7 @@ abstract class AbstractFactStoreTest {
         val fact3Id = FactId.generate()
         val fact3 = Fact(
             id = fact3Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_CREATED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now(),
@@ -1297,10 +1217,7 @@ abstract class AbstractFactStoreTest {
         val fact4Id = FactId.generate()
         val fact4 = Fact(
             id = fact4Id,
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_LOCKED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now(),
@@ -1341,10 +1258,7 @@ abstract class AbstractFactStoreTest {
 
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "BOB",
-            ),
+            subject = Subject(BOB_SUBJECT_VALUE),
             type = "USER_LOCKED".toFactType(),
             payload = bobPayload,
             appendedAt = Instant.now(),
@@ -1353,10 +1267,7 @@ abstract class AbstractFactStoreTest {
 
         val fact2 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "ALICE",
-            ),
+            subject = Subject(ALICE_SUBJECT_VALUE),
             type = "USER_LOCKED".toFactType(),
             payload = alicePayload,
             appendedAt = Instant.now(),
@@ -1384,10 +1295,7 @@ abstract class AbstractFactStoreTest {
 
         val fact1 = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "USER",
-                id = "DOMI",
-            ),
+            subject = Subject("USER:DOMI"),
             type = "USER_LOCKED".toFactType(),
             payload = """{ "username": "DOMI" }""".toFactPayload(),
             appendedAt = Instant.now(),
@@ -1399,10 +1307,7 @@ abstract class AbstractFactStoreTest {
             facts = listOf(fact1),
             idempotencyKey = idempotencyKey,
             condition = AppendCondition.ExpectedLastFact(
-                subjectRef = SubjectRef(
-                    type = "USER",
-                    id = "DOMI",
-                ),
+                subject = Subject("USER:DOMI"),
                 expectedLastFactId = null
             )
         )
@@ -1426,10 +1331,7 @@ abstract class AbstractFactStoreTest {
 
         val fact1 = Fact(
             id = factId,
-            subjectRef = SubjectRef(
-                type = "TEST_TYPE",
-                id = "TEST_ID",
-            ),
+            subject = Subject("TEST_SUBJECT"),
             type = "TEST_FACT_TYPE".toFactType(),
             payload = """DATA""".toFactPayload(),
             appendedAt = Instant.now(),
@@ -1472,10 +1374,7 @@ abstract class AbstractFactStoreTest {
 
         val fact = Fact(
             id = FactId.generate(),
-            subjectRef = SubjectRef(
-                type = "TEST_TYPE",
-                id = "TEST_ID",
-            ),
+            subject = Subject("TEST_SUBJECT"),
             type = "TEST_FACT_TYPE".toFactType(),
             payload = """DATA""".toFactPayload(),
             appendedAt = Instant.now(),


### PR DESCRIPTION
Replaces the SubjectRef with a plain simple Subject. This avoids introducing restrictive modeling concepts that should better be decided by application developers. 