### PR TITLE
Initial Draft for gRPC API

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '32 9 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: java-kotlin
+          build-mode: manual
+        - language: javascript-typescript
+          build-mode: none
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      if: matrix.language == 'java-kotlin'
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Build (Java/Kotlin)
+      if: matrix.build-mode == 'manual'
+      run: ./gradlew compileJava compileKotlin --no-daemon -x test
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"
+        ram: 4096

--- a/GRPC_tests
+++ b/GRPC_tests
@@ -1,0 +1,104 @@
+  # List services
+  grpcurl -plaintext localhost:9000 list
+
+  # Describe a service (shows all RPCs and types)
+  grpcurl -plaintext localhost:9000 describe io.factstore.server.grpc.StoreService
+  grpcurl -plaintext localhost:9000 describe io.factstore.server.grpc.FactService
+
+  # Describe a message type
+  grpcurl -plaintext localhost:9000 describe io.factstore.server.grpc.AppendFactsRequest
+
+  ---
+  StoreService
+  # Create a store
+  grpcurl -plaintext -d '{"name": "orders"}' \
+    localhost:9000 io.factstore.server.grpc.StoreService/CreateStore
+
+  # Get a store
+  grpcurl -plaintext -d '{"name": "orders"}' \
+    localhost:9000 io.factstore.server.grpc.StoreService/GetStore
+
+  # List all stores
+  grpcurl -plaintext localhost:9000 io.factstore.server.grpc.StoreService/ListStores
+
+  # Check existence (no body needed)
+  grpcurl -plaintext -d '{"name": "orders"}' \
+    localhost:9000 io.factstore.server.grpc.StoreService/StoreExists
+
+  # Delete a store
+  grpcurl -plaintext -d '{"name": "orders"}' \
+    localhost:9000 io.factstore.server.grpc.StoreService/DeleteStore
+
+  ---
+  FactService — append
+  # payload.data must be base64-encoded bytes
+  grpcurl -plaintext -d '{
+    "store_name": "orders",
+    "facts": [{
+      "type": "OrderCreated",
+      "subject": "order-42",
+      "payload": { "data": "eyJvcmRlcklkIjogNDJ9" }
+    }]
+  }' localhost:9000 io.factstore.server.grpc.FactService/AppendFacts
+  grpcurl -plaintext -d '{"name": "orders"}' \
+    localhost:9000 io.factstore.server.grpc.StoreService/StoreExists
+
+  # Delete a store
+  grpcurl -plaintext -d '{"name": "orders"}' \
+    localhost:9000 io.factstore.server.grpc.StoreService/DeleteStore
+
+  ---
+  FactService — append
+  # payload.data must be base64-encoded bytes
+  grpcurl -plaintext -d '{
+    "store_name": "orders",
+    "facts": [{
+      "type": "OrderCreated",
+      "subject": "order-42",
+      "payload": { "data": "eyJvcmRlcklkIjogNDJ9" }
+    }]
+  }' localhost:9000 io.factstore.server.grpc.FactService/AppendFacts
+
+  ---
+  FactService — query
+  # Get a fact by ID
+  grpcurl -plaintext -d '{
+    "store_name": "orders",
+    "fact_id": "<uuid-from-append>"
+  }' localhost:9000 io.factstore.server.grpc.FactService/GetFact
+
+  # Find by subject
+  grpcurl -plaintext -d '{
+    "store_name": "orders",
+    "subject": "order-42",
+    "limit": 10,
+    "direction": "FORWARD"
+  }' localhost:9000 io.factstore.server.grpc.FactService/FindFactsBySubject
+
+  # Find by tags
+  grpcurl -plaintext -d '{
+    "store_name": "orders",
+    "tags": {"region": "eu"}
+  }' localhost:9000 io.factstore.server.grpc.FactService/FindFactsByTags
+
+  ---
+  FactService — streaming
+
+  grpcurl handles server-side streaming transparently — it prints each fact as it arrives:
+  # Stream from the beginning (stays open, prints new facts as they arrive)
+  grpcurl -plaintext -d '{"store_name": "orders"}' \
+    localhost:9000 io.factstore.server.grpc.FactService/StreamFacts
+
+  # Stream only new facts from this point onward
+  grpcurl -plaintext -d '{"store_name": "orders", "from_end": true}' \
+    localhost:9000 io.factstore.server.grpc.FactService/StreamFacts
+
+  ---
+  InfoService
+  grpcurl -plaintext localhost:9000 io.factstore.server.grpc.InfoService/GetServerInfo
+
+  ---
+  If reflection isn't enabled in production mode, you can point grpcurl at the proto file instead:
+  grpcurl -plaintext -proto factstore-server/src/main/proto/factstore.proto \
+    -d '{"name": "orders"}' \
+    localhost:9000 io.factstore.server.grpc.StoreService/CreateStore

--- a/factstore-server/README.md
+++ b/factstore-server/README.md
@@ -183,3 +183,250 @@ The connection remains open and emits new facts as they are appended.
 - The `after` parameter allows resuming from a known fact ID. 
 - Streaming uses `text/event-stream` (SSE). 
 - Each event contains one serialized Fact.
+
+---
+
+## gRPC API (Experimental)
+
+FactStore also exposes a gRPC API that covers the same operations as the HTTP API.
+gRPC uses binary-encoded Protocol Buffers over HTTP/2, which makes it well-suited for service-to-service communication and high-throughput workloads.
+
+> ⚠️ **Status:** The gRPC API is currently **experimental** and may change without notice.
+
+### Connection
+
+The gRPC server runs on the **same port as the HTTP server** (default `8080`), multiplexed over HTTP/2.
+
+```
+Host: localhost
+Port: 8080
+Protocol: plaintext HTTP/2 (h2c)
+```
+
+The full service definitions live in:
+
+```
+factstore-server/src/main/proto/factstore.proto
+```
+
+Pass the proto file directly to tools that need it (e.g. grpcurl in environments where reflection is disabled):
+
+```bash
+grpcurl -plaintext \
+  -proto factstore-server/src/main/proto/factstore.proto \
+  -d '{"name": "orders"}' \
+  localhost:8080 io.factstore.server.grpc.StoreService/CreateStore
+```
+
+---
+
+### Services
+
+| Service | Description |
+|---|---|
+| `InfoService` | Server metadata (version, storage backend) |
+| `StoreService` | Create, inspect, and delete named stores |
+| `FactService` | Append, query, and stream facts within a store |
+
+---
+
+### InfoService
+
+#### GetServerInfo
+
+Returns the running server version and active storage backend.
+
+```bash
+grpcurl -plaintext localhost:8080 io.factstore.server.grpc.InfoService/GetServerInfo
+```
+
+---
+
+### StoreService
+
+#### CreateStore
+
+```bash
+grpcurl -plaintext \
+  -d '{"name": "orders"}' \
+  localhost:8080 io.factstore.server.grpc.StoreService/CreateStore
+```
+
+Outcomes: `created` (with UUID) · `name_already_exists`
+
+#### GetStore
+
+```bash
+grpcurl -plaintext \
+  -d '{"name": "orders"}' \
+  localhost:8080 io.factstore.server.grpc.StoreService/GetStore
+```
+
+Outcomes: `found` (with store info) · `not_found`
+
+#### ListStores
+
+```bash
+grpcurl -plaintext localhost:8080 io.factstore.server.grpc.StoreService/ListStores
+```
+
+#### StoreExists
+
+```bash
+grpcurl -plaintext \
+  -d '{"name": "orders"}' \
+  localhost:8080 io.factstore.server.grpc.StoreService/StoreExists
+```
+
+#### DeleteStore
+
+```bash
+grpcurl -plaintext \
+  -d '{"name": "orders"}' \
+  localhost:8080 io.factstore.server.grpc.StoreService/DeleteStore
+```
+
+Outcomes: `deleted` · `not_found`
+
+---
+
+### FactService
+
+#### AppendFacts
+
+`payload.data` must be base64-encoded bytes.
+
+```bash
+grpcurl -plaintext \
+  -d '{
+    "store_name": "orders",
+    "facts": [{
+      "type": "OrderCreated",
+      "subject": "order-42",
+      "payload": { "data": "eyJvcmRlcklkIjogNDJ9" },
+      "tags": { "region": "eu" }
+    }]
+  }' \
+  localhost:8080 io.factstore.server.grpc.FactService/AppendFacts
+```
+
+Outcomes: `appended` · `already_applied` · `condition_violated` · `duplicate_fact_ids` (with IDs) · `store_not_found`
+
+An optional `idempotency_key` (UUID string) makes the operation safe to retry. An optional `condition` enables conditional appends — see the proto file for the available condition types.
+
+#### GetFact
+
+```bash
+grpcurl -plaintext \
+  -d '{"store_name": "orders", "fact_id": "<uuid>"}' \
+  localhost:8080 io.factstore.server.grpc.FactService/GetFact
+```
+
+Outcomes: `found` (with fact) · `not_found` · `store_not_found`
+
+#### FactExists
+
+```bash
+grpcurl -plaintext \
+  -d '{"store_name": "orders", "fact_id": "<uuid>"}' \
+  localhost:8080 io.factstore.server.grpc.FactService/FactExists
+```
+
+Outcomes: `present` · `not_found` · `store_not_found`
+
+#### FindFactsBySubject
+
+```bash
+grpcurl -plaintext \
+  -d '{"store_name": "orders", "subject": "order-42", "limit": 50, "direction": "FORWARD"}' \
+  localhost:8080 io.factstore.server.grpc.FactService/FindFactsBySubject
+```
+
+Outcomes: `found` (with facts list, possibly empty) · `store_not_found`
+
+`direction` is `FORWARD` (oldest first, default) or `BACKWARD` (newest first). `limit` of `0` means no limit.
+
+#### FindFactsByTags
+
+```bash
+grpcurl -plaintext \
+  -d '{"store_name": "orders", "tags": {"region": "eu"}}' \
+  localhost:8080 io.factstore.server.grpc.FactService/FindFactsByTags
+```
+
+All specified tags must match (AND semantics). Outcomes: `found` · `store_not_found`
+
+#### QueryFacts
+
+Supports compound tag queries with OR-of-AND semantics, optionally filtered by fact type.
+
+```bash
+grpcurl -plaintext \
+  -d '{
+    "store_name": "orders",
+    "query": {
+      "items": [
+        { "tag_only": { "tags": { "region": "eu" } } },
+        { "tag_type": { "types": ["OrderCreated"], "tags": { "env": "prod" } } }
+      ]
+    }
+  }' \
+  localhost:8080 io.factstore.server.grpc.FactService/QueryFacts
+```
+
+Outcomes: `found` · `store_not_found`
+
+#### FindFactsInTimeRange
+
+```bash
+grpcurl -plaintext \
+  -d '{
+    "store_name": "orders",
+    "from": "2026-01-01T00:00:00Z",
+    "to":   "2026-02-01T00:00:00Z"
+  }' \
+  localhost:8080 io.factstore.server.grpc.FactService/FindFactsInTimeRange
+```
+
+Both `from` (inclusive) and `to` (exclusive) are optional. Omitting both returns all facts. Outcomes: `found` · `store_not_found`
+
+#### StreamFacts
+
+Opens a long-lived server-side stream. grpcurl prints each fact as it arrives.
+
+```bash
+# Replay all existing facts, then receive new ones as they are appended
+grpcurl -plaintext \
+  -d '{"store_name": "orders"}' \
+  localhost:8080 io.factstore.server.grpc.FactService/StreamFacts
+
+# Receive only facts appended after the stream is opened
+grpcurl -plaintext \
+  -d '{"store_name": "orders", "from_end": true}' \
+  localhost:8080 io.factstore.server.grpc.FactService/StreamFacts
+
+# Resume from a known fact ID
+grpcurl -plaintext \
+  -d '{"store_name": "orders", "after_fact_id": "<uuid>"}' \
+  localhost:8080 io.factstore.server.grpc.FactService/StreamFacts
+```
+
+Store-not-found and unknown `after_fact_id` are signalled as a `NOT_FOUND` gRPC status, not a response message field.
+
+---
+
+### Response model
+
+Every operation returns a response message with a `oneof outcome` field. Each case is a named, typed message that carries exactly the data belonging to that outcome — there are no ambiguous optional fields.
+
+For example, `AppendFactsResponse` looks like this conceptually:
+
+```
+outcome = appended            {}
+        | already_applied     {}
+        | condition_violated  {}
+        | duplicate_fact_ids  { fact_ids: [string] }
+        | store_not_found     { store_name: string }
+```
+
+Inspect the full definitions in the proto file to see all outcome types and their fields.

--- a/factstore-server/build.gradle.kts
+++ b/factstore-server/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(enforcedPlatform(libs.io.quarkus.platform.quarkus.bom))
     implementation("io.quarkus:quarkus-rest")
     implementation("io.quarkus:quarkus-rest-jackson")
+    implementation("io.quarkus:quarkus-grpc")
     implementation("io.quarkus:quarkus-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.quarkus:quarkus-arc")
@@ -16,6 +17,11 @@ dependencies {
     implementation("io.quarkus:quarkus-smallrye-openapi")
     implementation("io.quarkus:quarkus-smallrye-health")
     implementation(libs.quarkus.quinoa)
+    implementation("com.google.protobuf:protobuf-kotlin:4.35.0")
+    implementation("io.vertx:vertx-lang-kotlin-coroutines")
+    implementation("io.smallrye.reactive:mutiny-kotlin:3.2.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk9:1.8.1")
+
 
     // factstore libs
     implementation(project(":factstore-specification"))
@@ -45,5 +51,13 @@ kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
         javaParameters = true
+    }
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir("build/classes/java/quarkus-generated-sources/grpc")
+        }
     }
 }

--- a/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcConverters.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcConverters.kt
@@ -1,0 +1,150 @@
+package io.factstore.server.grpc
+
+import com.google.protobuf.ByteString
+import com.google.protobuf.Timestamp
+import io.factstore.core.*
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.future.future
+import kotlinx.coroutines.jdk9.asPublisher
+import java.time.Instant
+import java.util.*
+import io.factstore.core.ReadDirection as CoreReadDirection
+
+
+/**
+ * Converts a suspending function into a Mutiny [Uni].
+ *
+ * This bridge is necessary because Quarkus gRPC generates service stubs based on Mutiny
+ * ([Uni] and [Multi]) rather than Kotlin coroutines. Until Quarkus provides native support
+ * for grpc-kotlin coroutine stubs, service implementations must return Mutiny types while
+ * still allowing business logic to be written in idiomatic Kotlin with coroutines.
+ *
+ * Internally uses [future] from `kotlinx-coroutines-jdk9` to produce a [java.util.concurrent.CompletableFuture],
+ * which Mutiny natively understands via [Uni.createFrom().completionStage()]. Both successful
+ * results and exceptions are propagated correctly.
+ *
+ * @param block The suspending function to execute.
+ * @return A [Uni] that emits the result of [block], or fails if [block] throws.
+ */
+internal fun <T> CoroutineScope.toUni(block: suspend () -> T): Uni<T> =
+    Uni.createFrom().completionStage(
+        future { block() }
+    )
+
+/**
+ * Converts a suspending function returning a [Flow] into a Mutiny [Multi].
+ *
+ * This bridge is necessary because Quarkus gRPC generates service stubs based on Mutiny
+ * ([Uni] and [Multi]) rather than Kotlin coroutines. Until Quarkus provides native support
+ * for grpc-kotlin coroutine stubs, server-streaming methods must return [Multi] while still
+ * allowing streaming logic to be written using idiomatic Kotlin [Flow].
+ *
+ * Internally uses [asPublisher] from `kotlinx-coroutines-jdk9` to convert the [Flow] into
+ * a [java.util.concurrent.Flow.Publisher], which Mutiny natively understands via
+ * [Multi.createFrom().publisher()]. The calling [CoroutineScope]'s coroutineContext is
+ * passed to [asPublisher] to ensure correct dispatcher and cancellation propagation.
+ *
+ * @param block The suspending function returning a [Flow] of items to stream.
+ * @return A [Multi] that emits the items produced by the [Flow], or fails if the [Flow] throws.
+ */
+internal fun <T : Any> CoroutineScope.toMulti(
+    block: suspend () -> Flow<T>
+): Multi<T> {
+    val publisher = flow { emitAll(block()) }.asPublisher(this.coroutineContext)
+    return Multi.createFrom().publisher(publisher)
+}
+
+
+internal fun Instant.toTimestamp(): Timestamp = Timestamp.newBuilder()
+    .setSeconds(epochSecond)
+    .setNanos(nano)
+    .build()
+
+internal fun Timestamp.toInstant(): Instant = Instant.ofEpochSecond(seconds, nanos.toLong())
+
+internal fun Int.toLimit(): Limit = if (this > 0) Limit.of(this) else Limit.None
+
+internal fun FactStoreProto.ReadDirection.toCore(): CoreReadDirection = when (this) {
+    FactStoreProto.ReadDirection.BACKWARD -> CoreReadDirection.Backward
+    else -> CoreReadDirection.Forward
+}
+
+internal fun Fact.toProto(): FactStoreProto.Fact = fact {
+    id = this@toProto.id.uuid.toString()
+    type = this@toProto.type.value
+    subject = this@toProto.subject.value
+    appendedAt = this@toProto.appendedAt.toTimestamp()
+    payload = this@toProto.payload.toProto()
+    metadata.putAll(this@toProto.metadata)
+    tags.putAll(this@toProto.tags.entries.associate { (k, v) -> k.value to v.value })
+}
+
+internal fun FactPayload.toProto(): FactStoreProto.FactPayload = factPayload {
+    data = ByteString.copyFrom(this@toProto.data)
+    this@toProto.format?.let { format = it.value }
+    this@toProto.schema?.let { schemaRef = it.value }
+}
+
+internal fun StoreMetadata.toProto(): FactStoreProto.StoreInfo = storeInfo {
+    id = this@toProto.id.uuid.toString()
+    name = this@toProto.name.value
+    createdAt = this@toProto.createdAt.toTimestamp()
+}
+
+internal fun FactStoreProto.FactInput.toDomain(): Fact = Fact(
+    id = if (hasId()) UUID.fromString(id).toFactId() else FactId.generate(),
+    type = type.toFactType(),
+    subject = Subject(subject),
+    appendedAt = if (hasAppendedAt()) appendedAt.toInstant() else Instant.now(),
+    payload = payload.toDomain(),
+    metadata = metadataMap,
+    tags = tagsMap.entries.associate { (k, v) -> k.toTagKey() to v.toTagValue() }
+)
+
+internal fun FactStoreProto.FactPayload.toDomain(): FactPayload = FactPayload(
+    data = data.toByteArray(),
+    format = if (hasFormat()) PayloadFormat(format) else null,
+    schema = if (hasSchemaRef()) PayloadSchemaRef(schemaRef) else null
+)
+
+internal fun FactStoreProto.AppendCondition.toDomain(): AppendCondition = when (kindCase) {
+    FactStoreProto.AppendCondition.KindCase.EXPECTED_LAST_FACT -> AppendCondition.ExpectedLastFact(
+        subject = Subject(expectedLastFact.subject),
+        expectedLastFactId = if (expectedLastFact.hasExpectedLastFactId())
+            UUID.fromString(expectedLastFact.expectedLastFactId).toFactId()
+        else null
+    )
+    FactStoreProto.AppendCondition.KindCase.EXPECTED_MULTI_SUBJECT_LAST_FACT -> AppendCondition.ExpectedMultiSubjectLastFact(
+        expectations = expectedMultiSubjectLastFact.expectationsList.associate { exp ->
+            Subject(exp.subject) to
+                if (exp.hasExpectedLastFactId()) UUID.fromString(exp.expectedLastFactId).toFactId()
+                else null
+        }
+    )
+    FactStoreProto.AppendCondition.KindCase.TAG_QUERY_BASED -> AppendCondition.TagQueryBased(
+        failIfEventsMatch = tagQueryBased.failIfEventsMatch.toDomain(),
+        after = if (tagQueryBased.hasAfterFactId()) UUID.fromString(tagQueryBased.afterFactId).toFactId()
+        else null
+    )
+    else -> AppendCondition.None
+}
+
+internal fun FactStoreProto.TagQuery.toDomain(): TagQuery = TagQuery(
+    queryItems = itemsList.map { it.toDomain() }
+)
+
+internal fun FactStoreProto.TagQueryItem.toDomain(): TagQueryItem = when (kindCase) {
+    FactStoreProto.TagQueryItem.KindCase.TAG_ONLY -> TagOnlyQueryItem(
+        tags = tagOnly.tagsMap.entries.map { (k, v) -> k.toTagKey() to v.toTagValue() }
+    )
+    FactStoreProto.TagQueryItem.KindCase.TAG_TYPE -> TagTypeItem(
+        types = tagType.typesList.map { it.toFactType() },
+        tags = tagType.tagsMap.entries.map { (k, v) -> k.toTagKey() to v.toTagValue() }
+    )
+    else -> throw IllegalArgumentException("TagQueryItem has no kind set")
+}

--- a/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcFactService.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcFactService.kt
@@ -1,0 +1,186 @@
+package io.factstore.server.grpc
+
+import io.factstore.core.*
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.quarkus.grpc.GrpcService
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.Uni
+import io.vertx.core.Vertx
+import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import java.time.Instant
+import java.util.*
+
+@GrpcService
+class GrpcFactService(
+    private val factStore: FactStore,
+    vertx: Vertx,
+) : FactService, CoroutineScope by CoroutineScope(SupervisorJob() + vertx.dispatcher()) {
+
+    override fun appendFacts(request: FactStoreProto.AppendFactsRequest): Uni<FactStoreProto.AppendFactsResponse> =
+        toUni {
+            val facts = request.factsList.map { it.toDomain() }
+            val idempotencyKey = if (request.hasIdempotencyKey())
+                IdempotencyKey(UUID.fromString(request.idempotencyKey))
+            else
+                IdempotencyKey()
+            val condition = if (request.hasCondition()) request.condition.toDomain() else AppendCondition.None
+
+            val result = factStore.append(
+                AppendRequest(
+                    storeName = StoreName(request.storeName),
+                    facts = facts,
+                    idempotencyKey = idempotencyKey,
+                    condition = condition
+                )
+            )
+
+            appendFactsResponse {
+                when (result) {
+                    is AppendResult.Appended -> appended = factsAppended { }
+                    is AppendResult.AlreadyApplied -> alreadyApplied = alreadyApplied { }
+                    is AppendResult.AppendConditionViolated -> conditionViolated = conditionViolated { }
+                    is AppendResult.StoreNotFound -> storeNotFound = storeNotFound { storeName = result.storeName.value }
+                    is AppendResult.DuplicateFactIds -> duplicateFactIds = duplicateFactIds {
+                        factIds += result.factIds.map { it.uuid.toString() }
+                    }
+                }
+            }
+        }
+
+    override fun getFact(request: FactStoreProto.GetFactRequest): Uni<FactStoreProto.GetFactResponse> =
+        toUni {
+            val result = factStore.findById(
+                storeName = StoreName(request.storeName),
+                factId = UUID.fromString(request.factId).toFactId()
+            )
+            getFactResponse {
+                when (result) {
+                    is FindByIdResult.Found -> found = factFound { fact = result.fact.toProto() }
+                    is FindByIdResult.NotFound -> notFound = factNotFound { }
+                    is FindByIdResult.StoreNotFound -> storeNotFound = storeNotFound { storeName = result.storeName.value }
+                }
+            }
+        }
+
+    override fun factExists(request: FactStoreProto.FactExistsRequest): Uni<FactStoreProto.FactExistsResponse> =
+        toUni {
+            val result = factStore.existsById(
+                storeName = StoreName(request.storeName),
+                factId = UUID.fromString(request.factId).toFactId()
+            )
+            factExistsResponse {
+                when (result) {
+                    ExistsByIdResult.Exists -> present = factPresent { }
+                    ExistsByIdResult.DoesNotExist -> notFound = factNotFound { }
+                    ExistsByIdResult.StoreNotFound -> storeNotFound = storeNotFound { storeName = request.storeName }
+                }
+            }
+        }
+
+    override fun findFactsBySubject(request: FactStoreProto.FindFactsBySubjectRequest): Uni<FactStoreProto.FindFactsBySubjectResponse> =
+        toUni {
+            val result = factStore.findBySubject(
+                storeName = StoreName(request.storeName),
+                subject = Subject(request.subject),
+                limit = request.limit.toLimit(),
+                direction = request.direction.toCore()
+            )
+            findFactsBySubjectResponse {
+                when (result) {
+                    is FindBySubjectResult.Found ->
+                        found = factsFound { facts += result.facts.map { it.toProto() } }
+                    is FindBySubjectResult.StoreNotFound ->
+                        storeNotFound = storeNotFound { storeName = result.storeName.value }
+                }
+            }
+        }
+
+    override fun findFactsByTags(request: FactStoreProto.FindFactsByTagsRequest): Uni<FactStoreProto.FindFactsByTagsResponse> =
+        toUni {
+            val tags = request.tagsMap.entries.map { (k, v) -> k.toTagKey() to v.toTagValue() }
+            val result = factStore.findByTags(
+                storeName = StoreName(request.storeName),
+                tags = tags,
+                limit = request.limit.toLimit(),
+                direction = request.direction.toCore()
+            )
+            findFactsByTagsResponse {
+                when (result) {
+                    is FindByTagsResult.Found ->
+                        found = factsFound { facts += result.facts.map { it.toProto() } }
+                    is FindByTagsResult.StoreNotFound ->
+                        storeNotFound = storeNotFound { storeName = result.storeName.value }
+                }
+            }
+        }
+
+    override fun queryFacts(request: FactStoreProto.QueryFactsRequest): Uni<FactStoreProto.QueryFactsResponse> =
+        toUni {
+            val result = factStore.findByTagQuery(
+                storeName = StoreName(request.storeName),
+                query = request.query.toDomain()
+            )
+            queryFactsResponse {
+                when (result) {
+                    is FindByTagQueryResult.Found ->
+                        found = factsFound { facts += result.facts.map { it.toProto() } }
+                    is FindByTagQueryResult.StoreNotFound ->
+                        storeNotFound = storeNotFound { storeName = result.storeName.value }
+                }
+            }
+        }
+
+    override fun findFactsInTimeRange(request: FactStoreProto.FindFactsInTimeRangeRequest): Uni<FactStoreProto.FindFactsInTimeRangeResponse> =
+        toUni {
+            val result = factStore.findInTimeRange(
+                storeName = StoreName(request.storeName),
+                timeRange = TimeRange(
+                    start = if (request.hasFrom()) request.from.toInstant() else Instant.MIN,
+                    end = if (request.hasTo()) request.to.toInstant() else Instant.now()
+                ),
+                limit = request.limit.toLimit(),
+                direction = request.direction.toCore()
+            )
+            findFactsInTimeRangeResponse {
+                when (result) {
+                    is FindInTimeRangeResult.Found ->
+                        found = factsFound { facts += result.facts.map { it.toProto() } }
+                    is FindInTimeRangeResult.StoreNotFound ->
+                        storeNotFound = storeNotFound { storeName = result.storeName.value }
+                }
+            }
+        }
+
+    override fun streamFacts(
+        request: FactStoreProto.StreamFactsRequest
+    ): Multi<FactStoreProto.Fact> = toMulti {
+        val startPosition = when (request.startPositionCase) {
+            FactStoreProto.StreamFactsRequest.StartPositionCase.FROM_END -> StartPosition.End
+            FactStoreProto.StreamFactsRequest.StartPositionCase.AFTER_FACT_ID -> StartPosition.After(
+                UUID.fromString(request.afterFactId).toFactId()
+            )
+            else -> StartPosition.Beginning
+        }
+
+        flow {
+            when (val result = factStore.stream(
+                StoreName(request.storeName),
+                StreamingOptions(startPosition)
+            )) {
+                is StreamResult.StoreNotFound -> throw StatusRuntimeException(
+                    Status.NOT_FOUND.withDescription("Store '${result.storeName.value}' not found")
+                )
+                is StreamResult.FactIdNotFound -> throw StatusRuntimeException(
+                    Status.NOT_FOUND.withDescription("Fact '${result.id.uuid}' not found")
+                )
+                is StreamResult.FactStream -> emitAll(result.stream.map { it.toProto() })
+            }
+        }
+    }
+}

--- a/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcInfoService.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcInfoService.kt
@@ -1,0 +1,18 @@
+package io.factstore.server.grpc
+
+import io.quarkus.grpc.GrpcService
+import io.smallrye.mutiny.Uni
+import io.factstore.server.info.ServerInfo as CoreServerInfo
+
+@GrpcService
+class GrpcInfoService(private val info: CoreServerInfo) : InfoService {
+
+    override fun getServerInfo(request: FactStoreProto.GetServerInfoRequest): Uni<FactStoreProto.ServerInfo> =
+        Uni.createFrom().item(
+            serverInfo {
+                app = info.app
+                version = info.version
+                storageBackend = info.storageBackend
+            }
+        )
+}

--- a/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcStoreService.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcStoreService.kt
@@ -1,0 +1,68 @@
+package io.factstore.server.grpc
+
+import io.factstore.core.*
+import io.quarkus.grpc.GrpcService
+import io.smallrye.mutiny.Uni
+import io.vertx.core.Vertx
+import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+
+@GrpcService
+class GrpcStoreService(
+    private val factStore: FactStore,
+    vertx: Vertx,
+) : StoreService, CoroutineScope by CoroutineScope(SupervisorJob() + vertx.dispatcher()) {
+
+    override fun createStore(request: FactStoreProto.CreateStoreRequest): Uni<FactStoreProto.CreateStoreResponse> =
+        toUni {
+            val result = factStore.handle(CreateStoreRequest(StoreName(request.name)))
+            createStoreResponse {
+                when (result) {
+                    is CreateStoreResult.Created ->
+                        created = storeCreated { id = result.id.uuid.toString() }
+                    is CreateStoreResult.NameAlreadyExists ->
+                        nameAlreadyExists = storeNameAlreadyExists { }
+                }
+            }
+        }
+
+    override fun getStore(request: FactStoreProto.GetStoreRequest): Uni<FactStoreProto.GetStoreResponse> =
+        toUni {
+            val storeMetadata = factStore.findByName(StoreName(request.name))
+            getStoreResponse {
+                if (storeMetadata != null) {
+                    found = storeFound { store = storeMetadata.toProto() }
+                } else {
+                    notFound = storeNotFound { storeName = request.name }
+                }
+            }
+        }
+
+    override fun listStores(request: FactStoreProto.ListStoresRequest): Uni<FactStoreProto.ListStoresResponse> =
+        toUni {
+            val all = factStore.listAll()
+            listStoresResponse {
+                stores += all.map { it.toProto() }
+            }
+        }
+
+    override fun deleteStore(request: FactStoreProto.DeleteStoreRequest): Uni<FactStoreProto.DeleteStoreResponse> =
+        toUni {
+            val result = factStore.handle(RemoveStoreRequest(StoreName(request.name)))
+            deleteStoreResponse {
+                when (result) {
+                    is RemoveStoreResult.StoreRemoved -> deleted = storeDeleted { }
+                    is RemoveStoreResult.StoreNotFound -> notFound = storeNotFound { storeName = result.storeName.value }
+                }
+            }
+        }
+
+    override fun storeExists(request: FactStoreProto.StoreExistsRequest): Uni<FactStoreProto.StoreExistsResponse> =
+        toUni {
+            val found = factStore.existsByName(StoreName(request.name))
+            storeExistsResponse {
+                exists = found
+            }
+        }
+}

--- a/factstore-server/src/main/proto/factstore.proto
+++ b/factstore-server/src/main/proto/factstore.proto
@@ -1,0 +1,389 @@
+syntax = "proto3";
+
+package io.factstore.server.grpc;
+
+option java_package = "io.factstore.server.grpc";
+option java_outer_classname = "FactStoreProto";
+
+import "google/protobuf/timestamp.proto";
+
+// ─── Common Messages ──────────────────────────────────────────────────────────
+
+message Fact {
+  string id = 1;
+  string type = 2;
+  string subject = 3;
+  google.protobuf.Timestamp appended_at = 4;
+  FactPayload payload = 5;
+  map<string, string> metadata = 6;
+  map<string, string> tags = 7;
+}
+
+// Opaque fact data. format and schema_ref are optional hints for deserialization.
+message FactPayload {
+  bytes data = 1;
+  optional string format = 2;     // e.g. "json", "avro", "protobuf"
+  optional string schema_ref = 3; // schema registry reference
+}
+
+message StoreInfo {
+  string id = 1;
+  string name = 2;
+  google.protobuf.Timestamp created_at = 3;
+}
+
+enum ReadDirection {
+  FORWARD = 0;  // oldest to newest (default)
+  BACKWARD = 1; // newest to oldest
+}
+
+// ─── Tag Query ────────────────────────────────────────────────────────────────
+//
+// A TagQuery is a list of items evaluated with OR semantics: a fact matches if
+// it satisfies at least one item. Within each item, all tags/types are ANDed.
+
+message TagQuery {
+  repeated TagQueryItem items = 1;
+}
+
+message TagQueryItem {
+  oneof kind {
+    TagOnlyItem tag_only = 1;
+    TagTypeItem tag_type = 2;
+  }
+}
+
+// Matches facts that have all specified tags, regardless of type.
+message TagOnlyItem {
+  map<string, string> tags = 1;
+}
+
+// Matches facts whose type is in `types` AND that have all specified tags.
+message TagTypeItem {
+  repeated string types = 1;
+  map<string, string> tags = 2;
+}
+
+// ─── Append Condition ─────────────────────────────────────────────────────────
+
+// If absent on an AppendFactsRequest, no condition is applied.
+message AppendCondition {
+  oneof kind {
+    ExpectedLastFact expected_last_fact = 1;
+    ExpectedMultiSubjectLastFact expected_multi_subject_last_fact = 2;
+    TagQueryBasedCondition tag_query_based = 3;
+  }
+}
+
+// Append succeeds only if the last fact for `subject` has the given ID.
+// If expected_last_fact_id is absent, the condition requires no previous fact.
+message ExpectedLastFact {
+  string subject = 1;
+  optional string expected_last_fact_id = 2;
+}
+
+// Per-subject variant of ExpectedLastFact: each subject has its own expected last fact.
+message ExpectedMultiSubjectLastFact {
+  repeated SubjectExpectation expectations = 1;
+}
+
+message SubjectExpectation {
+  string subject = 1;
+  optional string expected_last_fact_id = 2;
+}
+
+// Append fails if any fact matching `fail_if_events_match` exists after `after_fact_id`.
+message TagQueryBasedCondition {
+  TagQuery fail_if_events_match = 1;
+  optional string after_fact_id = 2;
+}
+
+// ─── Shared Outcome Messages ──────────────────────────────────────────────────
+
+// The store with the given name does not exist.
+message StoreNotFound {
+  string store_name = 1;
+}
+
+// The fact with the requested ID does not exist.
+message FactNotFound {}
+
+// A set of facts (possibly empty) satisfying a query.
+message FactsFound {
+  repeated Fact facts = 1;
+}
+
+// ─── Store Service ────────────────────────────────────────────────────────────
+
+service StoreService {
+  rpc CreateStore(CreateStoreRequest) returns (CreateStoreResponse);
+  rpc GetStore(GetStoreRequest) returns (GetStoreResponse);
+  rpc ListStores(ListStoresRequest) returns (ListStoresResponse);
+  rpc DeleteStore(DeleteStoreRequest) returns (DeleteStoreResponse);
+  rpc StoreExists(StoreExistsRequest) returns (StoreExistsResponse);
+}
+
+// -- CreateStore --
+
+message CreateStoreRequest {
+  // Must match: ^[a-zA-Z]([a-zA-Z0-9_-]{0,253}[a-zA-Z0-9])?$|^[a-zA-Z]$
+  string name = 1;
+}
+
+message CreateStoreResponse {
+  oneof outcome {
+    StoreCreated created = 1;
+    StoreNameAlreadyExists name_already_exists = 2;
+  }
+}
+
+message StoreCreated {
+  string id = 1; // UUID of the created store
+}
+
+message StoreNameAlreadyExists {}
+
+// -- GetStore --
+
+message GetStoreRequest {
+  string name = 1;
+}
+
+message GetStoreResponse {
+  oneof outcome {
+    StoreFound found = 1;
+    StoreNotFound not_found = 2;
+  }
+}
+
+message StoreFound {
+  StoreInfo store = 1;
+}
+
+// -- ListStores --
+
+message ListStoresRequest {}
+
+message ListStoresResponse {
+  repeated StoreInfo stores = 1;
+}
+
+// -- DeleteStore --
+
+message DeleteStoreRequest {
+  string name = 1;
+}
+
+message DeleteStoreResponse {
+  oneof outcome {
+    StoreDeleted deleted = 1;
+    StoreNotFound not_found = 2;
+  }
+}
+
+message StoreDeleted {}
+
+// -- StoreExists --
+
+message StoreExistsRequest {
+  string name = 1;
+}
+
+message StoreExistsResponse {
+  bool exists = 1;
+}
+
+// ─── Fact Service ─────────────────────────────────────────────────────────────
+
+service FactService {
+  // Append one or more facts to a store, with optional idempotency and condition.
+  rpc AppendFacts(AppendFactsRequest) returns (AppendFactsResponse);
+
+  // Retrieve a single fact by its ID.
+  rpc GetFact(GetFactRequest) returns (GetFactResponse);
+
+  // Check whether a fact with the given ID exists.
+  rpc FactExists(FactExistsRequest) returns (FactExistsResponse);
+
+  // Find all facts for a subject, with optional limit and direction.
+  rpc FindFactsBySubject(FindFactsBySubjectRequest) returns (FindFactsBySubjectResponse);
+
+  // Find facts whose tags match ALL the specified key-value pairs.
+  rpc FindFactsByTags(FindFactsByTagsRequest) returns (FindFactsByTagsResponse);
+
+  // Find facts using a compound tag query (OR of AND-clauses, optionally filtered by type).
+  rpc QueryFacts(QueryFactsRequest) returns (QueryFactsResponse);
+
+  // Find facts within a half-open time range [from, to).
+  rpc FindFactsInTimeRange(FindFactsInTimeRangeRequest) returns (FindFactsInTimeRangeResponse);
+
+  // Open a server-side stream that emits existing facts and then continues to emit
+  // new facts as they are appended. Errors (store not found, after_fact_id not found)
+  // are signaled as gRPC status codes (NOT_FOUND).
+  rpc StreamFacts(StreamFactsRequest) returns (stream Fact);
+}
+
+// -- AppendFacts --
+
+// Input shape for a single fact to be appended.
+// id and appended_at are optional and will be auto-generated if absent.
+message FactInput {
+  optional string id = 1;
+  string type = 2;
+  string subject = 3;
+  optional google.protobuf.Timestamp appended_at = 4;
+  FactPayload payload = 5;
+  map<string, string> metadata = 6;
+  map<string, string> tags = 7;
+}
+
+message AppendFactsRequest {
+  string store_name = 1;
+  repeated FactInput facts = 2;
+  optional string idempotency_key = 3; // UUID; auto-generated if absent
+  optional AppendCondition condition = 4;
+}
+
+message AppendFactsResponse {
+  oneof outcome {
+    FactsAppended appended = 1;
+    AlreadyApplied already_applied = 2;
+    ConditionViolated condition_violated = 3;
+    DuplicateFactIds duplicate_fact_ids = 4;
+    StoreNotFound store_not_found = 5;
+  }
+}
+
+message FactsAppended {}
+message AlreadyApplied {}
+message ConditionViolated {}
+
+message DuplicateFactIds {
+  repeated string fact_ids = 1;
+}
+
+// -- GetFact --
+
+message GetFactRequest {
+  string store_name = 1;
+  string fact_id = 2;
+}
+
+message GetFactResponse {
+  oneof outcome {
+    FactFound found = 1;
+    FactNotFound not_found = 2;
+    StoreNotFound store_not_found = 3;
+  }
+}
+
+message FactFound {
+  Fact fact = 1;
+}
+
+// -- FactExists --
+
+message FactExistsRequest {
+  string store_name = 1;
+  string fact_id = 2;
+}
+
+message FactExistsResponse {
+  oneof outcome {
+    FactPresent present = 1;
+    FactNotFound not_found = 2;
+    StoreNotFound store_not_found = 3;
+  }
+}
+
+message FactPresent {}
+
+// -- FindFactsBySubject --
+
+message FindFactsBySubjectRequest {
+  string store_name = 1;
+  string subject = 2;
+  int32 limit = 3;         // 0 = no limit
+  ReadDirection direction = 4;
+}
+
+message FindFactsBySubjectResponse {
+  oneof outcome {
+    FactsFound found = 1;
+    StoreNotFound store_not_found = 2;
+  }
+}
+
+// -- FindFactsByTags --
+
+message FindFactsByTagsRequest {
+  string store_name = 1;
+  map<string, string> tags = 2; // all tags must match (AND semantics)
+  int32 limit = 3;              // 0 = no limit
+  ReadDirection direction = 4;
+}
+
+message FindFactsByTagsResponse {
+  oneof outcome {
+    FactsFound found = 1;
+    StoreNotFound store_not_found = 2;
+  }
+}
+
+// -- QueryFacts --
+
+message QueryFactsRequest {
+  string store_name = 1;
+  TagQuery query = 2;
+}
+
+message QueryFactsResponse {
+  oneof outcome {
+    FactsFound found = 1;
+    StoreNotFound store_not_found = 2;
+  }
+}
+
+// -- FindFactsInTimeRange --
+
+message FindFactsInTimeRangeRequest {
+  string store_name = 1;
+  optional google.protobuf.Timestamp from = 2; // inclusive; absent = no lower bound
+  optional google.protobuf.Timestamp to = 3;   // exclusive; absent = no upper bound
+  int32 limit = 4;                             // 0 = no limit
+  ReadDirection direction = 5;
+}
+
+message FindFactsInTimeRangeResponse {
+  oneof outcome {
+    FactsFound found = 1;
+    StoreNotFound store_not_found = 2;
+  }
+}
+
+// -- StreamFacts --
+
+message StreamFactsRequest {
+  string store_name = 1;
+  oneof start_position {
+    // Stream only new facts appended after the stream is opened.
+    bool from_end = 2;
+    // Stream facts appended after the given fact ID, then continue with new ones.
+    string after_fact_id = 3;
+    // If no field is set, streaming begins from the very first fact in the store.
+  }
+}
+
+// ─── Info Service ─────────────────────────────────────────────────────────────
+
+service InfoService {
+  rpc GetServerInfo(GetServerInfoRequest) returns (ServerInfo);
+}
+
+message GetServerInfoRequest {}
+
+message ServerInfo {
+  string app = 1;
+  string version = 2;
+  string storage_backend = 3;
+}

--- a/factstore-server/src/main/resources/application.yaml
+++ b/factstore-server/src/main/resources/application.yaml
@@ -3,6 +3,19 @@ quarkus:
     name: factstore-server
   banner:
     path: factstore-banner.txt
+  #############################
+  #   CODE GEN CONFIGURATION  #
+  #############################
+  generate-code:
+    grpc:
+      kotlin:
+        generate: true
+  #############################
+  #   GRPC API CONFIGURATION  #
+  #############################
+  grpc:
+    server:
+      use-separate-server: false
 
   #############################
   #   REST API CONFIGURATION  #

--- a/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcFactServiceTest.kt
+++ b/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcFactServiceTest.kt
@@ -1,0 +1,366 @@
+package io.factstore.server.grpc
+
+import com.google.protobuf.ByteString
+import io.grpc.StatusRuntimeException
+import io.quarkus.grpc.GrpcClient
+import io.quarkus.test.junit.QuarkusTest
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.jdk9.asFlow
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import java.util.UUID
+
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation::class)
+@TestInstance(PER_CLASS)
+class GrpcFactServiceTest {
+
+    @GrpcClient
+    lateinit var factService: FactService
+
+    @GrpcClient
+    lateinit var storeService: StoreService
+
+    val seedFactId: UUID = UUID.randomUUID()
+    val seedIdempotencyKey: String = UUID.randomUUID().toString()
+
+    companion object {
+        const val STORE = "grpc-fact-store"
+        const val SUBJECT = "order-99"
+    }
+
+    @BeforeAll
+    fun setUp(): Unit = runBlocking {
+        storeService.createStore(createStoreRequest { name = STORE }).awaitSuspending()
+    }
+
+    // ─── AppendFacts ─────────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    @DisplayName("AppendFacts - should return FactsAppended when facts are new")
+    fun appendFacts(): Unit = runBlocking {
+        val fid = seedFactId.toString()
+        val ikey = seedIdempotencyKey
+        val response = factService.appendFacts(appendFactsRequest {
+            storeName = STORE
+            idempotencyKey = ikey
+            facts += factInput {
+                id = fid
+                type = "order.created"
+                subject = SUBJECT
+                payload = factPayload { data = ByteString.copyFromUtf8("{}") }
+                tags["region"] = "eu"
+            }
+        }).awaitSuspending()
+
+        assertThat(response.hasAppended()).isTrue()
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("AppendFacts - should return AlreadyApplied when idempotency key was already used")
+    fun appendFactsAlreadyApplied(): Unit = runBlocking {
+        val ikey = seedIdempotencyKey
+        val response = factService.appendFacts(appendFactsRequest {
+            storeName = STORE
+            idempotencyKey = ikey
+            facts += factInput {
+                type = "order.created"
+                subject = SUBJECT
+                payload = factPayload { data = ByteString.copyFromUtf8("{}") }
+            }
+        }).awaitSuspending()
+
+        assertThat(response.hasAlreadyApplied()).isTrue()
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("AppendFacts - should return ConditionViolated when condition is not satisfied")
+    fun appendFactsConditionViolated(): Unit = runBlocking {
+        val wrongId = UUID.randomUUID().toString()
+        val response = factService.appendFacts(appendFactsRequest {
+            storeName = STORE
+            facts += factInput {
+                type = "order.updated"
+                subject = SUBJECT
+                payload = factPayload { data = ByteString.copyFromUtf8("{}") }
+            }
+            condition = appendCondition {
+                expectedLastFact = expectedLastFact {
+                    subject = SUBJECT
+                    expectedLastFactId = wrongId
+                }
+            }
+        }).awaitSuspending()
+
+        assertThat(response.hasConditionViolated()).isTrue()
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("AppendFacts - should return DuplicateFactIds when a fact ID is already in use")
+    fun appendFactsDuplicateIds(): Unit = runBlocking {
+        val fid = seedFactId.toString()
+        val response = factService.appendFacts(appendFactsRequest {
+            storeName = STORE
+            facts += factInput {
+                id = fid
+                type = "order.created"
+                subject = SUBJECT
+                payload = factPayload { data = ByteString.copyFromUtf8("{}") }
+            }
+        }).awaitSuspending()
+
+        assertThat(response.hasDuplicateFactIds()).isTrue()
+        assertThat(response.duplicateFactIds.factIdsList).containsExactly(seedFactId.toString())
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("AppendFacts - should return StoreNotFound when store does not exist")
+    fun appendFactsStoreNotFound(): Unit = runBlocking {
+        val response = factService.appendFacts(appendFactsRequest {
+            storeName = "ghost-store"
+            facts += factInput {
+                type = "order.created"
+                subject = SUBJECT
+                payload = factPayload { data = ByteString.copyFromUtf8("{}") }
+            }
+        }).awaitSuspending()
+
+        assertThat(response.hasStoreNotFound()).isTrue()
+        assertThat(response.storeNotFound.storeName).isEqualTo("ghost-store")
+    }
+
+    // ─── GetFact ─────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(6)
+    @DisplayName("GetFact - should return FactFound with the correct fact")
+    fun getFact(): Unit = runBlocking {
+        val response = factService.getFact(getFactRequest {
+            storeName = STORE
+            factId = seedFactId.toString()
+        }).awaitSuspending()
+
+        assertThat(response.hasFound()).isTrue()
+        assertThat(response.found.fact.id).isEqualTo(seedFactId.toString())
+        assertThat(response.found.fact.subject).isEqualTo(SUBJECT)
+        assertThat(response.found.fact.type).isEqualTo("order.created")
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("GetFact - should return FactNotFound when fact does not exist")
+    fun getFactNotFound(): Unit = runBlocking {
+        val response = factService.getFact(getFactRequest {
+            storeName = STORE
+            factId = UUID.randomUUID().toString()
+        }).awaitSuspending()
+
+        assertThat(response.hasNotFound()).isTrue()
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("GetFact - should return StoreNotFound when store does not exist")
+    fun getFactStoreNotFound(): Unit = runBlocking {
+        val response = factService.getFact(getFactRequest {
+            storeName = "ghost-store"
+            factId = seedFactId.toString()
+        }).awaitSuspending()
+
+        assertThat(response.hasStoreNotFound()).isTrue()
+        assertThat(response.storeNotFound.storeName).isEqualTo("ghost-store")
+    }
+
+    // ─── FactExists ──────────────────────────────────────────────────────────
+
+    @Test
+    @Order(9)
+    @DisplayName("FactExists - should return FactPresent when fact exists")
+    fun factExists(): Unit = runBlocking {
+        val response = factService.factExists(factExistsRequest {
+            storeName = STORE
+            factId = seedFactId.toString()
+        }).awaitSuspending()
+
+        assertThat(response.hasPresent()).isTrue()
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("FactExists - should return FactNotFound when fact does not exist")
+    fun factDoesNotExist(): Unit = runBlocking {
+        val response = factService.factExists(factExistsRequest {
+            storeName = STORE
+            factId = UUID.randomUUID().toString()
+        }).awaitSuspending()
+
+        assertThat(response.hasNotFound()).isTrue()
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("FactExists - should return StoreNotFound when store does not exist")
+    fun factExistsStoreNotFound(): Unit = runBlocking {
+        val response = factService.factExists(factExistsRequest {
+            storeName = "ghost-store"
+            factId = seedFactId.toString()
+        }).awaitSuspending()
+
+        assertThat(response.hasStoreNotFound()).isTrue()
+        assertThat(response.storeNotFound.storeName).isEqualTo("ghost-store")
+    }
+
+    // ─── FindFactsBySubject ───────────────────────────────────────────────────
+
+    @Test
+    @Order(12)
+    @DisplayName("FindFactsBySubject - should return FactsFound with matching facts")
+    fun findFactsBySubject(): Unit = runBlocking {
+        val response = factService.findFactsBySubject(findFactsBySubjectRequest {
+            storeName = STORE
+            subject = SUBJECT
+        }).awaitSuspending()
+
+        assertThat(response.hasFound()).isTrue()
+        assertThat(response.found.factsList).hasSize(1)
+        assertThat(response.found.factsList.first().subject).isEqualTo(SUBJECT)
+    }
+
+    @Test
+    @Order(13)
+    @DisplayName("FindFactsBySubject - should return StoreNotFound when store does not exist")
+    fun findFactsBySubjectStoreNotFound(): Unit = runBlocking {
+        val response = factService.findFactsBySubject(findFactsBySubjectRequest {
+            storeName = "ghost-store"
+            subject = SUBJECT
+        }).awaitSuspending()
+
+        assertThat(response.hasStoreNotFound()).isTrue()
+    }
+
+    // ─── FindFactsByTags ──────────────────────────────────────────────────────
+
+    @Test
+    @Order(14)
+    @DisplayName("FindFactsByTags - should return FactsFound with facts matching the tags")
+    fun findFactsByTags(): Unit = runBlocking {
+        val response = factService.findFactsByTags(findFactsByTagsRequest {
+            storeName = STORE
+            tags["region"] = "eu"
+        }).awaitSuspending()
+
+        assertThat(response.hasFound()).isTrue()
+        assertThat(response.found.factsList).isNotEmpty()
+        assertThat(response.found.factsList.first().tagsMap).containsEntry("region", "eu")
+    }
+
+    @Test
+    @Order(15)
+    @DisplayName("FindFactsByTags - should return StoreNotFound when store does not exist")
+    fun findFactsByTagsStoreNotFound(): Unit = runBlocking {
+        val response = factService.findFactsByTags(findFactsByTagsRequest {
+            storeName = "ghost-store"
+            tags["region"] = "eu"
+        }).awaitSuspending()
+
+        assertThat(response.hasStoreNotFound()).isTrue()
+    }
+
+    // ─── QueryFacts ───────────────────────────────────────────────────────────
+
+    @Test
+    @Order(16)
+    @DisplayName("QueryFacts - should return FactsFound using a tag-only query")
+    fun queryFacts(): Unit = runBlocking {
+        val response = factService.queryFacts(queryFactsRequest {
+            storeName = STORE
+            query = tagQuery {
+                items += tagQueryItem {
+                    tagOnly = tagOnlyItem { tags["region"] = "eu" }
+                }
+            }
+        }).awaitSuspending()
+
+        assertThat(response.hasFound()).isTrue()
+        assertThat(response.found.factsList).isNotEmpty()
+    }
+
+    @Test
+    @Order(17)
+    @DisplayName("QueryFacts - should return StoreNotFound when store does not exist")
+    fun queryFactsStoreNotFound(): Unit = runBlocking {
+        val response = factService.queryFacts(queryFactsRequest {
+            storeName = "ghost-store"
+            query = tagQuery {
+                items += tagQueryItem {
+                    tagOnly = tagOnlyItem { tags["region"] = "eu" }
+                }
+            }
+        }).awaitSuspending()
+
+        assertThat(response.hasStoreNotFound()).isTrue()
+    }
+
+    // ─── FindFactsInTimeRange ─────────────────────────────────────────────────
+
+    @Test
+    @Order(18)
+    @DisplayName("FindFactsInTimeRange - should return FactsFound for an unbounded time range")
+    fun findFactsInTimeRange(): Unit = runBlocking {
+        val response = factService.findFactsInTimeRange(findFactsInTimeRangeRequest {
+            storeName = STORE
+            // no from/to — unbounded range matches all facts in the store
+        }).awaitSuspending()
+
+        assertThat(response.hasFound()).isTrue()
+        assertThat(response.found.factsList).isNotEmpty()
+    }
+
+    @Test
+    @Order(19)
+    @DisplayName("FindFactsInTimeRange - should return StoreNotFound when store does not exist")
+    fun findFactsInTimeRangeStoreNotFound(): Unit = runBlocking {
+        val response = factService.findFactsInTimeRange(findFactsInTimeRangeRequest {
+            storeName = "ghost-store"
+        }).awaitSuspending()
+
+        assertThat(response.hasStoreNotFound()).isTrue()
+    }
+
+    // ─── StreamFacts ──────────────────────────────────────────────────────────
+
+    @Test
+    @Order(20)
+    @DisplayName("StreamFacts - should emit existing facts from the beginning of the store")
+    fun streamFacts(): Unit = runBlocking {
+        val facts = factService.streamFacts(streamFactsRequest {
+            storeName = STORE
+        }).asFlow().take(1).toList()
+
+        assertThat(facts).hasSize(1)
+        assertThat(facts.first().id).isEqualTo(seedFactId.toString())
+    }
+
+    @Test
+    @Order(21)
+    @DisplayName("StreamFacts - should fail with StatusRuntimeException when store does not exist")
+    fun streamFactsStoreNotFound(): Unit {
+        assertThrows<StatusRuntimeException> {
+            runBlocking {
+                factService.streamFacts(streamFactsRequest {
+                    storeName = "ghost-store"
+                }).asFlow().toList()
+            }
+        }
+    }
+}

--- a/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcInfoServiceTest.kt
+++ b/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcInfoServiceTest.kt
@@ -1,0 +1,28 @@
+package io.factstore.server.grpc
+
+import io.quarkus.grpc.GrpcClient
+import io.quarkus.test.junit.QuarkusTest
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class GrpcInfoServiceTest {
+
+    @GrpcClient
+    lateinit var infoService: InfoService
+
+    @ConfigProperty(name = "quarkus.application.version")
+    private lateinit var version: String
+
+    @Test
+    fun `getServerInfo returns expected app metadata`(): Unit = runBlocking {
+        val info = infoService.getServerInfo(getServerInfoRequest { }).awaitSuspending()
+
+        assertThat(info.app).isEqualTo("factstore-server-test")
+        assertThat(info.version).isEqualTo(version)
+        assertThat(info.storageBackend).isEqualTo("memory")
+    }
+}

--- a/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcStoreServiceTest.kt
+++ b/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcStoreServiceTest.kt
@@ -1,0 +1,117 @@
+package io.factstore.server.grpc
+
+import io.quarkus.grpc.GrpcClient
+import io.quarkus.test.junit.QuarkusTest
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import java.util.UUID
+
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation::class)
+@TestInstance(PER_CLASS)
+class GrpcStoreServiceTest {
+
+    @GrpcClient
+    lateinit var storeService: StoreService
+
+    @BeforeAll
+    fun setUp(): Unit = runBlocking {
+        storeService.createStore(createStoreRequest { name = "grpc-store-a" }).awaitSuspending()
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("CreateStore - should return StoreCreated with a valid UUID when name is available")
+    fun createStore(): Unit = runBlocking {
+        val response = storeService.createStore(createStoreRequest { name = "grpc-store-new" }).awaitSuspending()
+
+        assertThat(response.hasCreated()).isTrue()
+        assertThat(response.created.id).isNotBlank()
+        assertThatCode { UUID.fromString(response.created.id) }.doesNotThrowAnyException()
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("CreateStore - should return NameAlreadyExists when name is already taken")
+    fun createStoreDuplicate(): Unit = runBlocking {
+        val response = storeService.createStore(createStoreRequest { name = "grpc-store-a" }).awaitSuspending()
+
+        assertThat(response.hasNameAlreadyExists()).isTrue()
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("GetStore - should return StoreFound with store info when store exists")
+    fun getStore(): Unit = runBlocking {
+        val response = storeService.getStore(getStoreRequest { name = "grpc-store-a" }).awaitSuspending()
+
+        assertThat(response.hasFound()).isTrue()
+        assertThat(response.found.store.name).isEqualTo("grpc-store-a")
+        assertThat(response.found.store.id).isNotBlank()
+        assertThat(response.found.store.hasCreatedAt()).isTrue()
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("GetStore - should return StoreNotFound when store does not exist")
+    fun getStoreNotFound(): Unit = runBlocking {
+        val response = storeService.getStore(getStoreRequest { name = "no-such-store" }).awaitSuspending()
+
+        assertThat(response.hasNotFound()).isTrue()
+        assertThat(response.notFound.storeName).isEqualTo("no-such-store")
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("StoreExists - should return exists=true when store is present")
+    fun storeExists(): Unit = runBlocking {
+        val response = storeService.storeExists(storeExistsRequest { name = "grpc-store-a" }).awaitSuspending()
+
+        assertThat(response.exists).isTrue()
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("StoreExists - should return exists=false when store is absent")
+    fun storeDoesNotExist(): Unit = runBlocking {
+        val response = storeService.storeExists(storeExistsRequest { name = "no-such-store" }).awaitSuspending()
+
+        assertThat(response.exists).isFalse()
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("ListStores - should include all created stores")
+    fun listStores(): Unit = runBlocking {
+        storeService.createStore(createStoreRequest { name = "grpc-store-b" }).awaitSuspending()
+
+        val response = storeService.listStores(listStoresRequest { }).awaitSuspending()
+
+        val names = response.storesList.map { it.name }
+        assertThat(names).contains("grpc-store-a", "grpc-store-b")
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("DeleteStore - should return StoreDeleted when store exists")
+    fun deleteStore(): Unit = runBlocking {
+        val response = storeService.deleteStore(deleteStoreRequest { name = "grpc-store-a" }).awaitSuspending()
+
+        assertThat(response.hasDeleted()).isTrue()
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("DeleteStore - should return StoreNotFound when store does not exist")
+    fun deleteStoreNotFound(): Unit = runBlocking {
+        val response = storeService.deleteStore(deleteStoreRequest { name = "grpc-store-a" }).awaitSuspending()
+
+        assertThat(response.hasNotFound()).isTrue()
+        assertThat(response.notFound.storeName).isEqualTo("grpc-store-a")
+    }
+}


### PR DESCRIPTION
This development adds a gRPC API to factstore-server, which mimics the same APIs already exposed by HTTP. The gRPC API is supposed to be used by client SDKs as well as the CLI for better type-safety, performance, and streaming capabilities.