### PR TITLE
Version and move gRPC-related code to neutral package

### DIFF
--- a/factstore-server/README.md
+++ b/factstore-server/README.md
@@ -207,7 +207,7 @@ Pass the proto file directly to tools that need it (e.g. grpcurl in environments
 
 ```bash
 grpcurl -plaintext \
-  -proto factstore-server/src/main/proto/factstore.proto \
+  -proto factstore-server/src/main/proto/factstore-v1.proto \
   -d '{"name": "orders"}' \
   localhost:8080 io.factstore.server.grpc.StoreService/CreateStore
 ```

--- a/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcConverters.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcConverters.kt
@@ -3,6 +3,7 @@ package io.factstore.server.grpc
 import com.google.protobuf.ByteString
 import com.google.protobuf.Timestamp
 import io.factstore.core.*
+import io.factstore.grpc.v1.*
 import java.time.Instant
 import java.util.*
 import io.factstore.core.ReadDirection as CoreReadDirection

--- a/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcFactService.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcFactService.kt
@@ -1,22 +1,9 @@
 package io.factstore.server.grpc
 
 import io.factstore.core.*
-import io.factstore.server.grpc.FactStoreProto.AppendFactsRequest
-import io.factstore.server.grpc.FactStoreProto.AppendFactsResponse
-import io.factstore.server.grpc.FactStoreProto.Fact
-import io.factstore.server.grpc.FactStoreProto.FactExistsRequest
-import io.factstore.server.grpc.FactStoreProto.FactExistsResponse
-import io.factstore.server.grpc.FactStoreProto.FindFactsBySubjectRequest
-import io.factstore.server.grpc.FactStoreProto.FindFactsBySubjectResponse
-import io.factstore.server.grpc.FactStoreProto.FindFactsByTagsRequest
-import io.factstore.server.grpc.FactStoreProto.FindFactsByTagsResponse
-import io.factstore.server.grpc.FactStoreProto.FindFactsInTimeRangeRequest
-import io.factstore.server.grpc.FactStoreProto.FindFactsInTimeRangeResponse
-import io.factstore.server.grpc.FactStoreProto.GetFactRequest
-import io.factstore.server.grpc.FactStoreProto.GetFactResponse
-import io.factstore.server.grpc.FactStoreProto.QueryFactsRequest
-import io.factstore.server.grpc.FactStoreProto.QueryFactsResponse
-import io.factstore.server.grpc.FactStoreProto.StreamFactsRequest
+import io.factstore.grpc.v1.FactService
+import io.factstore.grpc.v1.FactStoreProto
+import io.factstore.grpc.v1.FactStoreProto.*
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import io.quarkus.grpc.GrpcService
@@ -80,7 +67,7 @@ class GrpcFactService(
 
     override fun streamFacts(
         request: StreamFactsRequest
-    ): Multi<Fact> = toMulti(grpcContext) {
+    ): Multi<FactStoreProto.Fact> = toMulti(grpcContext) {
         val startPosition = when (request.startPositionCase) {
             StreamFactsRequest.StartPositionCase.FROM_END -> StartPosition.End
             StreamFactsRequest.StartPositionCase.AFTER_FACT_ID -> StartPosition.After(

--- a/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcInfoService.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcInfoService.kt
@@ -1,5 +1,8 @@
 package io.factstore.server.grpc
 
+import io.factstore.grpc.v1.FactStoreProto
+import io.factstore.grpc.v1.InfoService
+import io.factstore.grpc.v1.serverInfo
 import io.quarkus.grpc.GrpcService
 import io.smallrye.mutiny.Uni
 import io.factstore.server.info.ServerInfo as CoreServerInfo

--- a/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcStoreService.kt
+++ b/factstore-server/src/main/kotlin/io/factstore/server/grpc/GrpcStoreService.kt
@@ -1,6 +1,8 @@
 package io.factstore.server.grpc
 
 import io.factstore.core.*
+import io.factstore.grpc.v1.FactStoreProto
+import io.factstore.grpc.v1.StoreService
 import io.quarkus.grpc.GrpcService
 import io.smallrye.mutiny.Uni
 import io.vertx.core.Vertx

--- a/factstore-server/src/main/proto/factstore-v1.proto
+++ b/factstore-server/src/main/proto/factstore-v1.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package io.factstore.server.grpc;
 
-option java_package = "io.factstore.server.grpc";
+option java_package = "io.factstore.grpc.v1";
 option java_outer_classname = "FactStoreProto";
 
 import "google/protobuf/timestamp.proto";

--- a/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcFactServiceTest.kt
+++ b/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcFactServiceTest.kt
@@ -1,6 +1,7 @@
 package io.factstore.server.grpc
 
 import com.google.protobuf.ByteString
+import io.factstore.grpc.v1.*
 import io.grpc.StatusRuntimeException
 import io.quarkus.grpc.GrpcClient
 import io.quarkus.test.junit.QuarkusTest

--- a/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcFactServiceTest.kt
+++ b/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcFactServiceTest.kt
@@ -396,7 +396,7 @@ class GrpcFactServiceTest {
     @Test
     @Order(23)
     @DisplayName("StreamFacts - should fail with StatusRuntimeException when store does not exist")
-    fun streamFactsStoreNotFound(): Unit {
+    fun streamFactsStoreNotFound() {
         assertThrows<StatusRuntimeException> {
             runBlocking {
                 factService.streamFacts(streamFactsRequest {

--- a/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcInfoServiceTest.kt
+++ b/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcInfoServiceTest.kt
@@ -1,5 +1,6 @@
 package io.factstore.server.grpc
 
+import io.factstore.grpc.v1.*
 import io.quarkus.grpc.GrpcClient
 import io.quarkus.test.junit.QuarkusTest
 import io.smallrye.mutiny.coroutines.awaitSuspending

--- a/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcStoreServiceTest.kt
+++ b/factstore-server/src/test/kotlin/io/factstore/server/grpc/GrpcStoreServiceTest.kt
@@ -1,5 +1,6 @@
 package io.factstore.server.grpc
 
+import io.factstore.grpc.v1.*
 import io.quarkus.grpc.GrpcClient
 import io.quarkus.test.junit.QuarkusTest
 import io.smallrye.mutiny.coroutines.awaitSuspending


### PR DESCRIPTION
This allows us to evolve the API in the future (by introducing versioning early on) and moves the generated code to a neutral package that can be used for both the server and the clients (at least the JVM based clients).